### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/alessbarb/IntentLang/security/code-scanning/1](https://github.com/alessbarb/IntentLang/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, the workflow only needs to read repository contents, so set `permissions: contents: read` at the top level of the workflow (just after the `name` field and before `on`). This will apply the restriction to all jobs in the workflow. No changes to imports, methods, or other definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
