### PR TITLE
docs: translate repository to English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,64 +1,64 @@
-# AGENTS.md — Guía para agentes en IntentLang (IL)
+# AGENTS.md — Guide for IntentLang (IL)
 
-> Documento vivo. Orienta a agentes automatizados y humanos sobre **qué pueden hacer**, **cómo** y **con qué garantías** en este monorepo.
+> Living document for automated agents and humans. It describes what you may change, how, and with what guarantees in this monorepo.
 
 ## TL;DR
 
-- Trabaja **determinista**, seguro y con cambios mínimos.
-- Usa `ilc` para todo: `check | build | test | fmt | inspect | goldens`.
-- Antes de abrir PR: actualiza EBNF/lexer/parser **en conjunto**, ejecuta **goldens**, añade pruebas.
-- Nunca subas secretos ni hagas llamadas externas no aprobadas. Si hay dudas —eleva a humana/o.
+- Work deterministically, safely, and with minimal changes.
+- Use `ilc` for everything: `check | build | test | fmt | inspect | goldens`.
+- Before opening a PR: update EBNF/lexer/parser together, run golden tests, add tests.
+- Never commit secrets or make unapproved network calls. Escalate to a human if unsure.
 
 ---
 
-## 1) Contexto del repo
+## 1) Repository context
 
-**Paquetes principales:**
+**Main packages:**
 
 - `packages/core` — AST, lexer, parser, checker, transpiler, runtime.
-- `packages/cli` — CLI `ilc`.
-- `packages/examples` — ejemplos canónicos y **goldens** (salida TS esperada).
+- `packages/cli` — `ilc` command-line tool.
+- `packages/examples` — canonical examples and golden outputs (expected TS code).
 
-**Arquitectura del lenguaje** (resumen):
+**Language architecture (summary):**
 
-- AST con `Program` + secciones (`intent`, `uses`, `types`) y _top-level items_ (`func`, `effect`, `test`).
-- Tipado total con `Option`/`Result`, `match` exhaustivo.
-- Transpilación principal → TypeScript.
-
----
-
-## 2) Principios para agentes
-
-1. **Determinismo primero** — usa semillas y reloj fijo cuando corresponda.
-2. **Cambios mínimos** — evita refactors masivos sin RFC.
-3. **Contrato ZFA** (Zero‑Fault Authoring) — no dejes el repo en rojo: si introduces una regla, añade test o golden.
-4. **Exhaustividad** — si tocas `match`, `union` o `types`, asegúrate de coberturas en checker y goldens.
-5. **Sin sorpresas** — no añadas dependencias sin justificar; documenta flags y códigos de error.
-6. **Privacidad y seguridad** — no exportes código/ficheros a servicios externos.
+- AST with `Program` and sections (`intent`, `uses`, `types`) plus top-level items (`func`, `effect`, `test`).
+- Total typing with `Option`/`Result` and exhaustive `match`.
+- Main transpilation target → TypeScript.
 
 ---
 
-## 3) Alcance y límites
+## 2) Principles for agents
 
-**Puede:**
-
-- Editar código en `core`, `cli`, `examples` siguiendo esta guía.
-- Abrir PRs con cambios pequeños o medianos.
-- Escribir/actualizar documentación y goldens.
-
-**No puede:**
-
-- Cambiar licencias o políticas de privacidad.
-- Introducir telemetría remota.
-- Publicar versiones o crear releases sin aprobación humana.
-
-Si el cambio afecta **semántica del lenguaje** (p. ej., sintaxis nueva, ruptura del AST, reglas de exhaustividad), **abre una RFC** antes.
+1. **Determinism first** — use seeds and fixed clock when needed.
+2. **Minimal changes** — avoid large refactors without an RFC.
+3. **Zero-Fault Authoring** — keep the repo green; new rules need tests or golden updates.
+4. **Exhaustiveness** — changes to `match`, `union` or `types` must be covered in checker and goldens.
+5. **No surprises** — avoid new dependencies; document flags and error codes.
+6. **Privacy and security** — never export code/files to external services.
 
 ---
 
-## 4) Herramientas del proyecto
+## 3) Scope and limits
 
-Comandos `ilc` esperados (algunos pueden vivir tras flags si aún no existen):
+**Allowed:**
+
+- Edit code in `core`, `cli`, `examples` following this guide.
+- Open small or medium PRs.
+- Write/update documentation and goldens.
+
+**Disallowed:**
+
+- Change licenses or privacy policies.
+- Introduce remote telemetry.
+- Publish releases without human approval.
+
+If a change affects **language semantics** (e.g., new syntax, AST breakage, exhaustiveness rules), open an **RFC** first.
+
+---
+
+## 4) Project tools
+
+Expected `ilc` commands:
 
 ```bash
 ilc check <files/globs> [--strict] [--json] [--watch] [--max-errors N]
@@ -70,7 +70,7 @@ ilc goldens run|update [--only NAME] [--yes]
 ilc doctor
 ```
 
-Utilidades de Node/pnpm:
+Node/pnpm helpers:
 
 ```bash
 pnpm i
@@ -78,109 +78,109 @@ pnpm -w build
 pnpm -w typecheck
 ```
 
-Flags de determinismo (runtime): `--seed-rng`, `--seed-clock`.
+Runtime determinism flags: `--seed-rng`, `--seed-clock`.
 
 ---
 
-## 5) Flujo estándar de cambios
+## 5) Standard change flow
 
-### 5.1 Cambios en gramática/sintaxis
+### 5.1 Grammar/syntax changes
 
-1. Actualiza la **EBNF** en documentación (o sección README correspondiente).
-2. Modifica **lexer** y **parser** en conjunto —evita estados intermedios incoherentes.
-3. Añade **tests** de parsing e incluye ejemplos `.il`.
-4. Ejecuta `ilc inspect tokens|ast` para validar árboles.
-5. Si afecta al checker/transpiler, sigue los flujos 5.2/5.3.
+1. Update the **EBNF** in documentation or README.
+2. Modify **lexer** and **parser** together — avoid inconsistent intermediate states.
+3. Add **parsing tests** and include `.il` examples.
+4. Run `ilc inspect tokens|ast` to validate trees.
+5. If it affects the checker/transpiler, follow 5.2/5.3.
 
-### 5.2 Cambios en checker
+### 5.2 Checker changes
 
-1. Añade nuevos **diagnósticos** con código `ILC000x` y mensaje claro.
-2. Implementa la regla y cubre con tests unitarios y ejemplos `.il`.
-3. Si la regla cambia salidas esperadas, actualiza **goldens**.
+1. Add new **diagnostics** with code `ILC000x` and clear message.
+2. Implement the rule and cover with unit tests and `.il` examples.
+3. If the rule changes expected outputs, update **goldens**.
 
-### 5.3 Cambios en transpiler
+### 5.3 Transpiler changes
 
-1. Garantiza **salida estable** y determinista (orden de campos/casos).
-2. Añade/actualiza goldens relevantes en `packages/examples/goldens`.
-3. Ejecuta `ilc goldens run` y verifica diffs.
+1. Ensure **stable, deterministic output** (order of fields/cases).
+2. Add/update relevant goldens in `packages/examples/goldens`.
+3. Run `ilc goldens run` and verify diffs.
 
-### 5.4 Cambios en CLI
+### 5.4 CLI changes
 
-1. Añade el comando/flag y su ayuda (`--help`).
-2. Implementa salida **humana** y **JSON** si aplica.
-3. Añade tests E2E con fixtures `.il`.
+1. Add the command/flag and its `--help` output.
+2. Implement **human** and **JSON** output when applicable.
+3. Add E2E tests with `.il` fixtures.
 
-### 5.5 Cambios en runtime
+### 5.5 Runtime changes
 
-1. Mantén APIs pequeñas; documenta seeds y reloj.
-2. Cubre con tests unitarios.
-
----
-
-## 6) Checklist de PR (obligatorio)
-
-Marca todo lo que aplique antes de pedir revisión:
-
-- [ ] `ilc fmt` sin cambios pendientes o `--check` limpio.
-- [ ] `ilc check` sin errores —y sin _warnings_ si `--strict` se usa en CI.
-- [ ] Tests unitarios y E2E pasan.
-- [ ] `ilc goldens run` sin diffs —o `goldens update` justificado en la descripción.
-- [ ] Documentación actualizada (README/EBNF/AGENTS.md si aplica).
-- [ ] Sin dependencias nuevas no justificadas.
-- [ ] Sin llamadas externas ni exposición de secretos.
+1. Keep APIs small; document seeds and clock.
+2. Cover with unit tests.
 
 ---
 
-## 7) Convenciones de commits y PRs
+## 6) PR checklist (required)
+
+Tick what applies before requesting review:
+
+- [ ] `ilc fmt` has no pending changes or passes with `--check`.
+- [ ] `ilc check` reports no errors (and no warnings with `--strict` in CI).
+- [ ] Unit and E2E tests pass.
+- [ ] `ilc goldens run` shows no diffs — or `goldens update` is justified in the description.
+- [ ] Documentation updated (README/EBNF/AGENTS if applicable).
+- [ ] No unjustified new dependencies.
+- [ ] No external calls or secret leakage.
+
+---
+
+## 7) Commit and PR conventions
 
 - **Conventional Commits**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `perf:`.
-- Prefiere PRs pequeños, con una intención clara.
-- Descripción breve con **motivación**, **cambio**, **riesgos** y **cómo probar**.
+- Prefer small PRs with a clear intent.
+- Provide a short description with **motivation**, **change**, **risks**, and **how to test**.
 
-Plantilla de PR:
+PR template:
 
 ```md
-### Motivo
+### Motivation
 
-¿Qué problema resuelve? ¿Por qué ahora?
+What problem does it solve? Why now?
 
-### Cambios
+### Changes
 
-Lista corta con bullets.
+Short bullet list.
 
-### Riesgos y mitigaciones
+### Risks and mitigations
 
-Impacto en parser/checker/transpiler/CLI, flags, backward-compat.
+Impact on parser/checker/transpiler/CLI, flags, backward-compat.
 
-### Pruebas
+### Tests
 
-Comandos ejecutados, goldens afectados.
+Commands run, goldens affected.
 ```
 
 ---
 
-## 8) Política de diagnósticos (ILC000x)
+## 8) Diagnostic policy (ILC000x)
 
-- Todo mensaje de error/aviso público debe tener un **código único**.
-- `--explain ILC000x` imprime contexto y ejemplo mínimo.
-- Evita términos ambiguos; incluye posición (línea/columna) y _snippet_ con `^`.
+- Every public error/warning must have a **unique code**.
+- `--explain ILC000x` prints context and a minimal example.
+- Avoid ambiguous terms; include position (line/column) and snippet with `^`.
 
-Ejemplos de categorías:
+Example categories:
 
-- ILC010x — Léxico/Parser.
-- ILC020x — Tipado/Exhaustividad.
-- ILC030x — Capacidades/Efectos.
+- ILC010x — Lexing/Parser.
+- ILC020x — Typing/Exhaustiveness.
+- ILC030x — Capabilities/Effects.
 - ILC040x — CLI/Flags/Config.
 
 ---
 
-## 9) Goldens y ejemplos
+## 9) Goldens and examples
 
-- Cada ejemplo `.il` debe tener su **golden** `.ts` equivalente.
-- El **prelude** TS para goldens vive en `packages/examples/goldens/_prelude.ts`.
-- Usa `ilc goldens update --only <name>` para aceptar cambios deliberados.
+- Each `.il` example must have a matching `.ts` **golden**.
+- The TS **prelude** for goldens lives in `packages/examples/goldens/_prelude.ts`.
+- Use `ilc goldens update --only <name>` to accept deliberate changes.
 
-Estructura sugerida de ejemplo:
+Suggested example structure:
 
 ```tree
 packages/examples/
@@ -198,83 +198,83 @@ packages/examples/
 
 ---
 
-## 10) Seguridad y privacidad
+## 10) Security and privacy
 
-- No subas llaves, tokens ni rutas privadas.
-- No agregues telemetría ni dependencias que hagan **red** por defecto.
-- Si necesitas _fixtures_ con datos, **anonimiza**.
+- Do not commit keys, tokens or private paths.
+- Do not add telemetry or dependencies that make **network** calls by default.
+- If fixtures contain data, **anonymize** it.
 
-Escalada obligatoria:
+Mandatory escalation:
 
-- Cambios de licencia, gobernanza o _compliance_.
-- Integraciones de red, sandbox o ejecución de código no confiable.
-
----
-
-## 11) Rendimiento y trazas
-
-- Usa `ilc --trace` para cronometrar `lex|parse|check|emit|write`.
-- Si un cambio empeora tiempos >10% en goldens medianos, coméntalo en el PR y aporta alternativa.
+- Changes to license, governance or compliance.
+- Network integrations, sandboxing or execution of untrusted code.
 
 ---
 
-## 12) Estabilidad del AST y versionado
+## 11) Performance and tracing
 
-- Cambios que rompen AST → **minor** en `@il/core` y nota de migración.
-- Añadir nodos/campos opcionales es preferible a romper campos existentes.
-- Documenta en `CHANGELOG.md` y ajusta goldens.
+- Use `ilc --trace` to time `lex|parse|check|emit|write`.
+- If a change worsens timings >10% on medium goldens, mention it in the PR and offer alternatives.
 
 ---
 
-## 13) Estilo de código y formato
+## 12) AST stability and versioning
+
+- Breaking AST changes → **minor** bump in `@il/core` and migration notes.
+- Prefer adding optional nodes/fields over breaking existing ones.
+- Document in `CHANGELOG.md` and adjust goldens.
+
+---
+
+## 13) Code style and formatting
 
 - TypeScript ESM, Node ≥20.
-- Sin `console.*` de depuración en código de producción.
-- `ilc fmt` es fuente de verdad para `.il`.
+- No debug `console.*` in production code.
+- `ilc fmt` is the source of truth for `.il` files.
 
 ---
 
-## 14) Plantillas rápidas para agentes
+## 14) Quick templates for agents
 
-### 14.1 Cambio pequeño en parser
+### 14.1 Small parser change
 
-- [ ] Actualicé EBNF.
-- [ ] Cambié tokens en `lexer.ts`.
-- [ ] Ajusté `parser.ts` y añadí caso al _printer_ si aplica.
-- [ ] Añadí ejemplo `.il` y test.
+- [ ] Updated EBNF.
+- [ ] Changed tokens in `lexer.ts`.
+- [ ] Adjusted `parser.ts` and added printer case if needed.
+- [ ] Added `.il` example and test.
 - [ ] `ilc inspect ast` OK.
 
-### 14.2 Nueva regla de checker
+### 14.2 New checker rule
 
-- [ ] Añadí código `ILC02xx` y mensaje.
-- [ ] Cobertura con test `.il` que falla y otro que pasa.
-- [ ] Actualicé docs `--explain`.
+- [ ] Added `ILC02xx` code and message.
+- [ ] Covered with failing and passing `.il` tests.
+- [ ] Updated `--explain` docs.
 
-### 14.3 Cambio en transpiler
+### 14.3 Transpiler change
 
-- [ ] Salida ordenada y determinista.
-- [ ] Goldens actualizados conscientemente.
-- [ ] `ilc goldens run` pasa.
-
----
-
-## 15) Preguntas frecuentes (para agentes)
-
-**¿Puedo renombrar símbolos públicos?** — Solo con migración y nota de ruptura.
-
-**¿Puedo añadir dependencias?** — Evítalo. Si es imprescindible, justifica: tamaño, seguridad, licencia, uso.
-
-**¿Puedo tocar todas las carpetas a la vez?** — Mejor no. Divide por PRs y describe el plan.
+- [ ] Deterministic output and ordering.
+- [ ] Goldens updated consciously.
+- [ ] `ilc goldens run` passes.
 
 ---
 
-## 16) Contacto y gobernanza
+## 15) Frequently asked questions
 
-- Mantainers: asigna el PR a quienes figuren en `CODEOWNERS` (si existe) o etiqueta `lang-core`, `cli`, `examples` según el área.
-- Las RFCs se abren en `/rfcs` con plantilla y tiempo de comentarios de 5 días laborables.
+**Can I rename public symbols?** — Only with migration notes and a breaking change.
+
+**Can I add dependencies?** — Avoid it. If essential, justify size, security, license and use.
+
+**Can I touch all folders at once?** — Prefer splitting into separate PRs and describe the plan.
 
 ---
 
-## 17) Última palabra
+## 16) Contact and governance
 
-Trabaja con intención —pequeño, seguro, claro. Si algo no encaja con estos principios, **para y consulta**. Mejor un PR pequeño bien explicado que una “gran mejora” que rompa todo.
+- Maintainers: assign the PR to those in `CODEOWNERS` (if present) or tag `lang-core`, `cli`, `examples` according to area.
+- RFCs live in `/rfcs` with a template and a 5 business day comment period.
+
+---
+
+## 17) Final word
+
+Work with intent—small, safe, clear. If something doesn't fit these principles, **stop and ask**. Better a small well-explained PR than a “big improvement” that breaks everything.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,99 +33,99 @@
 
 ## [0.4.0] — 2025-08-19
 
-### Añadido
+### Added
 
-- **Suites de tests** iniciales para _core_ y _CLI_; incorporación de **unit** y **end-to-end tests**.
-- **Guía de testing** y ejemplos en la documentación.
-- **Soporte de contratos en funciones** (documentación específica incluida).
-- **Documentación** sobre _seeds deterministas_ para RNG y clock.
-- Nuevos casos de prueba en _core_: `contracts.test.mjs`, `test-blocks.test.mjs`.
+- Initial **test suites** for core and CLI, including unit and end-to-end tests.
+- **Testing guide** and examples in the documentation.
+- **Function contracts** support with dedicated docs.
+- **Documentation** on deterministic seeds for RNG and clock.
+- New core tests: `contracts.test.mjs`, `test-blocks.test.mjs`.
 
-### Cambiado
+### Changed
 
 - **Core**
-  - Refinado del **parser** y **checker**.
-  - Mejoras en el **transpiler TypeScript**.
-  - Ajustes de exportaciones en `runtime/index.ts`.
+  - Refined **parser** and **checker**.
+  - Improvements to the **TypeScript transpiler**.
+  - Export tweaks in `runtime/index.ts`.
 
 - **CLI**
-  - Mejora del _entrypoint_ y cableado de comandos.
-  - Ampliación de los tests del CLI.
+  - Better entrypoint and command wiring.
+  - Expanded CLI tests.
 
 - **Workspace**
-  - Alineación de `package.json` en raíz y paquetes.
-  - Ajustes en `packages/core/tsconfig.json`.
-  - Pequeñas mejoras en `packages/examples/package.json`.
+  - Aligned root and package `package.json` files.
+  - Adjusted `packages/core/tsconfig.json`.
+  - Minor improvements to `packages/examples/package.json`.
 
 - **Docs**
-  - Actualización de `STYLEGUIDE.md`, `docs/README.md` y `CHANGELOG.md`.
+  - Updated `STYLEGUIDE.md`, `docs/README.md`, and `CHANGELOG.md`.
 
-### Eliminado
+### Removed
 
-- Limpiezas menores en diffs (remociones puntuales derivadas de refactors).
+- Minor diff cleanups from refactors.
 
-### Notas de migración
+### Migration notes
 
-- Los tests están en **ESM (`.mjs`)**. Recomendado **Node.js ≥ 20** (idealmente 22) y ejecutar con `vitest`/`node --test` según corresponda.
-- Mantener `pnpm-lock.yaml` como _lockfile_ de referencia (no usar `package-lock.json` en subpaquetes).
+- Tests use **ESM (`.mjs`)**. Recommend **Node.js ≥ 20** (ideally 22) and run with `vitest`/`node --test`.
+- Keep `pnpm-lock.yaml` as the reference lockfile; do not use `package-lock.json` in subpackages.
 
 ---
 
 ## [0.3.0] — 2025-08-18
 
-### Añadido
+### Added
 
-- **Configuración de Trunk** y _baseline_ de linters/formatters.
-- **Documentación**:
-  - `docs/plan.md`, `README.md` y `AGENTS.md`.
-  - Guías de contribución y estilo (`CONTRIBUTING.md`, `STYLEGUIDE.md`).
+- **Trunk** configuration and baseline for linters/formatters.
+- **Documentation**:
+  - `docs/plan.md`, `README.md`, and `AGENTS.md`.
+  - Contribution and style guides (`CONTRIBUTING.md`, `STYLEGUIDE.md`).
 
-- **Ejemplos** de IntentLang:
-  - Ficheros `.il` sincronizados con _golden outputs_ (`invoice_service`, `order_service`, `payment_service`, `user_service`, `notification_service`).
+- **IntentLang examples**:
+  - `.il` files synced with golden outputs (`invoice_service`, `order_service`, `payment_service`, `user_service`, `notification_service`).
 
-- **Licencia** del proyecto.
+- Project **license**.
 
-### Cambiado
+### Changed
 
-- **Core del lenguaje**
-  - Ampliación del **AST**, **checker**, **lexer** y **parser**.
-  - Mejoras en el **transpiler a TypeScript**.
-  - Revisión de exportaciones en `runtime/index.ts` y en `src/index.ts`.
+- **Language core**
+  - Expanded **AST**, **checker**, **lexer**, and **parser**.
+  - Improvements to the **TypeScript transpiler**.
+  - Export review in `runtime/index.ts` and `src/index.ts`.
 
 - **CLI**
-  - Mejora del _entrypoint_ y estructura de comandos.
+  - Improved entrypoint and command structure.
 
 - **Workspace/Build**
-  - Alineación de `pnpm-workspace.yaml`, `tsconfig.base.json`, `package.json` de paquetes y `pnpm-lock.yaml`.
-  - Refresco de `.gitignore` (añadidos temporales y artefactos).
+  - Aligned `pnpm-workspace.yaml`, `tsconfig.base.json`, package `package.json` files, and `pnpm-lock.yaml`.
+  - Refreshed `.gitignore` with temporaries and artifacts.
 
 - **Tests**
-  - Migración desde `.mts` a **ESM (`.mjs`)** y reubicación en `packages/core/tests/`.
+  - Migrated from `.mts` to **ESM (`.mjs`)** and relocated to `packages/core/tests/`.
 
-### Eliminado
+### Removed
 
-- Tests obsoletos en formato `.mts` tras la migración a `.mjs`.
+- Obsolete `.mts` tests after migration to `.mjs`.
 
-### Notas
+### Notes
 
-- Se establecen bases sólidas para **release notes** y automatización de QA con Trunk.
-- Mantener fuera del repo artefactos ignorados (`node_modules/`, salidas de _linters_, temporales en `tmp/`, etc.).
+- Established solid groundwork for **release notes** and QA automation with Trunk.
+- Keep ignored artifacts (`node_modules/`, linter outputs, temporaries in `tmp/`, etc.) out of the repo.
 
 ---
 
 ## [Unreleased]
 
-### Ideas / Próximos pasos
+### Ideas / Next steps
 
-- Consolidar **contratos** a lo largo de todas las construcciones del lenguaje (parser → checker → transpiler).
-- Extender **suites E2E** para CLI (comandos compuestos y _error paths_).
-- Documentar _best practices_ para escritura de especificaciones IL + generación de _goldens_.
-- Integración con _CI_ para publicar _artifacts_ de ejemplos y _reports_ de cobertura.
+- Consolidate **contracts** across all language constructs (parser → checker → transpiler).
+- Extend **E2E suites** for CLI (composite commands and error paths).
+- Document **best practices** for writing IL specs and generating goldens.
+- Integrate with CI to publish example artifacts and coverage reports.
 
 ---
 
-## Historial y coherencia
+## History and coherence
 
-- Se adopta **pnpm** como gestor de paquetes del monorepo; `pnpm-lock.yaml` es el _source of truth_.
-- Se consolidan **tests** en ESM y estructura homogénea por paquete.
-- La documentación se mantiene viva con foco en **ejemplos prácticos**, **contratos** y **guías de testing**.
+- The monorepo uses **pnpm**; `pnpm-lock.yaml` is the source of truth.
+- Tests are consolidated in ESM with a uniform structure per package.
+- Documentation stays alive with a focus on **practical examples**, **contracts**, and **testing guides**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
-# Documentación de IntentLang
+# IntentLang Documentation
 
-Bienvenido a la documentación oficial de **IntentLang**, un lenguaje declarativo diseñado para describir dominios y generar código TypeScript tipado.
+Welcome to the official documentation for **IntentLang**, a declarative language designed to describe domains and generate typed TypeScript code.
 
-## Contenido
+## Contents
 
-- [Guía de inicio rápido](guide/quickstart.md)
-- [Referencia del lenguaje](reference/syntax.md)
-  - [Tipos](reference/types.md)
-  - [Funciones y efectos](reference/functions.md)
+- [Quick Start Guide](guide/quickstart.md)
+- [Language Reference](reference/syntax.md)
+  - [Types](reference/types.md)
+  - [Functions and effects](reference/functions.md)
 
-Consulta cada sección para entender el flujo completo: desde escribir archivos `.il` hasta generar código ejecutable.
+Visit each section to understand the full workflow: from writing `.il` files to generating executable code.

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -1,19 +1,19 @@
-# Guía de inicio rápido
+# Quick Start Guide
 
-Esta guía muestra cómo escribir un archivo en IntentLang y generar el código TypeScript correspondiente.
+This guide shows how to write an IntentLang file and generate the corresponding TypeScript code.
 
-## Prerrequisitos
+## Prerequisites
 
-- Node.js y pnpm instalados
-- Dependencias del repositorio instaladas con:
+- Node.js and pnpm installed
+- Repository dependencies installed:
 
 ```bash
 pnpm install
 ```
 
-## Crear un servicio simple
+## Create a simple service
 
-Crea `user_service.il` con el siguiente contenido:
+Create `user_service.il` with the following content:
 
 ```intentlang
 intent "User service" tags ["api", "users"]
@@ -47,35 +47,35 @@ effect createUser(input: CreateUserInput): ResultUser uses http, clock
 test create_user { let now = clock.now(); }
 ```
 
-## Validar el archivo
+## Validate the file
 
 ```bash
 pnpm --filter @il/cli ilc check user_service.il
 ```
 
-## Generar TypeScript
+## Generate TypeScript
 
 ```bash
 pnpm --filter @il/cli ilc build user_service.il --target ts --out dist
 ```
 
-Se creará `dist/user_service.ts` con tipos y stubs equivalentes, listo para completar la lógica.
+`dist/user_service.ts` will contain equivalent types and stubs ready for business logic.
 
-Para obtener resultados reproducibles puedes fijar las semillas del generador pseudoaleatorio y del reloj:
+For reproducible results you can fix the pseudo-random generator and clock seeds:
 
 ```bash
 pnpm --filter @il/cli ilc build user_service.il --seed-rng 1 --seed-clock 0
 ```
 
-## Ejecutar pruebas
+## Run tests
 
-Para archivos que definan bloques `test`, puedes compilarlos y ejecutarlos con:
+For files with `test` blocks, compile and run them with:
 
 ```bash
 pnpm --filter @il/cli ilc test user_service.il
 ```
 
-Al igual que con `build`, es posible fijar semillas para repetir exactamente el comportamiento:
+As with `build`, you may seed the RNG and clock to replay behavior exactly:
 
 ```bash
 pnpm --filter @il/cli ilc test user_service.il --seed-rng 1 --seed-clock 0

--- a/docs/guide/tests.md
+++ b/docs/guide/tests.md
@@ -1,7 +1,6 @@
-# Pruebas
+# Testing
 
-IntentLang permite definir bloques de pruebas con la palabra clave `test`.
-Cada prueba puede invocar funciones o efectos existentes y se ejecuta a través de la CLI.
+IntentLang lets you define test blocks using the `test` keyword. Each test may call existing functions or effects and is executed through the CLI.
 
 ```intentlang
 uses { random: Random { } }
@@ -17,18 +16,18 @@ test deterministic {
   let sum = add(2, 3);
   let r1 = rollDie();
   let r2 = rollDie();
-  // asserts vendrán en futuras versiones
+  // assertions will come in future versions
 }
 ```
 
-Ejecuta las pruebas con:
+Run tests with:
 
 ```bash
-pnpm --filter @il/cli ilc test archivo.il
+pnpm --filter @il/cli ilc test file.il
 ```
 
-Para resultados reproducibles, fija las semillas del RNG y del reloj:
+For reproducible results, fix RNG and clock seeds:
 
 ```bash
-pnpm --filter @il/cli ilc test archivo.il --seed-rng 1 --seed-clock 0
+pnpm --filter @il/cli ilc test file.il --seed-rng 1 --seed-clock 0
 ```

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -1,16 +1,16 @@
-# Funciones y efectos
+# Functions and Effects
 
-Las **funciones** (`func`) son puras y deterministas, mientras que los **efectos** (`effect`) interactúan con el exterior y deben declarar sus capacidades en `uses`.
+**Functions** (`func`) are pure and deterministic, while **effects** (`effect`) interact with the outside world and must declare their capabilities in `uses`.
 
-## Funciones puras
+## Pure functions
 
 ```intentlang
 func toUpper(s: String): String {
-  // sin efectos
+  // no effects
 }
 ```
 
-## Efectos con dependencias
+## Effects with dependencies
 
 ```intentlang
 effect now(): DateTime uses clock {
@@ -18,11 +18,11 @@ effect now(): DateTime uses clock {
 }
 ```
 
-Las dependencias (`clock` en el ejemplo) se resuelven por inyección al generar el código TypeScript.
+Dependencies (e.g., `clock` above) are injected when generating TypeScript code.
 
-## Contratos (`requires` / `ensures`)
+## Contracts (`requires` / `ensures`)
 
-Las funciones y efectos pueden declarar **contratos** para documentar y validar sus supuestos.
+Functions and effects may declare **contracts** to document and validate assumptions.
 
 ```intentlang
 func add(a: Int, b: Int): Int requires a > 0 ensures a + b > 0 {
@@ -30,8 +30,8 @@ func add(a: Int, b: Int): Int requires a > 0 ensures a + b > 0 {
 }
 ```
 
-- `requires <expr>` se evalúa al inicio y aborta si es falso.
-- `ensures <expr>` se comprueba antes de cada `return`.
-- Las expresiones deben devolver `Bool` y solo pueden usar variables en el alcance.
+- `requires <expr>` runs at the start and aborts if false.
+- `ensures <expr>` runs before each `return`.
+- Expressions must return `Bool` and only use variables in scope.
 
-En la salida TypeScript, los contratos se traducen a `if` que lanzan `Error` cuando no se cumplen.
+In the TypeScript output, contracts become `if` statements that throw `Error` when not satisfied.

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -1,14 +1,14 @@
-# Sintaxis básica
+# Basic Syntax
 
-Un archivo `.il` debe seguir este orden de secciones:
+An `.il` file must follow this order of sections:
 
-1. `intent` – describe el servicio y sus etiquetas.
-2. `uses` – declara capacidades externas.
-3. `types` – define tipos de dominio.
-4. `func` – funciones puras.
-5. `effect` – funciones con efectos.
+1. `intent` – describes the service and its tags.
+2. `uses` – declares external capabilities.
+3. `types` – defines domain types.
+4. `func` – pure functions.
+5. `effect` – functions with effects.
 
-Ejemplo mínimo:
+Minimal example:
 
 ```intentlang
 intent "Ping" tags ["demo"]
@@ -22,13 +22,13 @@ types {
 }
 
 effect sendPing(): Result<Ping, String> uses clock {
-  // implementación pendiente
+  // implementation pending
 }
 ```
 
-## Contratos
+## Contracts
 
-Antes del cuerpo, las funciones y efectos pueden declarar cláusulas de contrato opcionales:
+Before the body, functions and effects may declare optional contract clauses:
 
 ```intentlang
 func add(a: Int, b: Int): Int requires a > 0 ensures a + b > 0 {
@@ -36,12 +36,12 @@ func add(a: Int, b: Int): Int requires a > 0 ensures a + b > 0 {
 }
 ```
 
-- `requires` valida una precondición.
-- `ensures` verifica una postcondición antes de cada `return`.
+- `requires` validates a precondition.
+- `ensures` checks a postcondition before each `return`.
 
-Si alguna falla, la ejecución arroja un `Error` en el código generado.
+If any fail, the execution throws an `Error` in the generated code.
 
-## Comentarios
+## Comments
 
-- `//` para comentarios de una línea.
-- `/* ... */` para bloques.
+- `//` for single-line comments.
+- `/* ... */` for blocks.

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -1,18 +1,18 @@
-# Tipos en IntentLang
+# Types in IntentLang
 
-IntentLang soporta tres formas principales de tipos: **marcas**, **registros** y **uniones**.
+IntentLang supports three main kinds of types: **brands**, **records**, and **unions**.
 
-## Marcas
+## Brands
 
-Permiten restringir `String` mediante un nombre y una condición:
+Restrict a `String` with a name and a condition:
 
 ```intentlang
 type Email = String brand "Email" where matches("^[^@]+@[^@]+\\.[^@]+$");
 ```
 
-## Registros
+## Records
 
-Colecciones con campos nombrados. Para más de tres campos, usa una línea por campo.
+Collections of named fields. For more than three fields, use one line per field.
 
 ```intentlang
 type User = {
@@ -23,9 +23,9 @@ type User = {
 };
 ```
 
-## Uniones
+## Unions
 
-Combinan alternativas etiquetadas que se deben manejar exhaustivamente con `match`.
+Combine tagged alternatives that must be handled exhaustively with `match`.
 
 ```intentlang
 type Payment =

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -1,36 +1,36 @@
-# AGENTS.md — Guía del paquete **CLI** (`ilc`)
+# AGENTS.md — CLI Package (`ilc`)
 
-**Ámbito**: binario, parsing de flags, reporting humano/JSON, códigos de salida y UX.
+**Scope**: binary, flag parsing, human/JSON reporting, exit codes and UX.
 
-## Principios
+## Principles
 
-- **UX clara**: mensajes cortos, accionables y con rutas normalizadas.
-- **Salida dual**: humana por defecto y `--json` para máquinas.
-- **Códigos estables**: `0` ok, `1` fallos lógicos, `2` uso/flags/config.
+- **Clear UX**: short actionable messages with normalized paths.
+- **Dual output**: human by default and `--json` for machines.
+- **Stable codes**: `0` success, `1` logical failures, `2` usage/flags/config errors.
 
-## Subcomandos esperados
+## Expected subcommands
 
-- `check` `build` `test` `fmt` `inspect` `goldens (run|update)` `doctor` `init` `targets` `cache`.
+`check` `build` `test` `fmt` `inspect` `goldens (run|update)` `doctor` `init` `targets` `cache`
 
-## Reglas de implementación
+## Implementation rules
 
-- **Flags globales**: `--strict`, `--json`, `--watch`, `--seed-rng`, `--seed-clock`.
-- **Diagnósticos**: imprimidos con snippet y caret; en `--json` como array `diags[]` + `status`.
-- **Watch**: _debounce_ de 100–300 ms, limpieza de pantalla opcional.
-- **Globs**: expándelos de forma cross‑platform; soporta `-` para `stdin`.
-- **Help**: `ilc --help` y `<cmd> --help` con ejemplos.
-- **Sin telemetría**: nada de red por defecto.
+- **Global flags**: `--strict`, `--json`, `--watch`, `--seed-rng`, `--seed-clock`.
+- **Diagnostics**: printed with snippet and caret; in `--json` mode as `diags[]` + `status`.
+- **Watch mode**: 100–300 ms debounce, optional screen clearing.
+- **Globs**: cross-platform expansion; support `-` for `stdin`.
+- **Help**: `ilc --help` and `<cmd> --help` with examples.
+- **No telemetry**: no network usage by default.
 
-## Checklist de PR (CLI)
+## PR checklist (CLI)
 
-- [ ] Subcomando/flag documentado en `--help`.
-- [ ] Reporters humano/JSON coherentes y testeados.
-- [ ] `exitCode` correcto en escenarios de error.
-- [ ] E2E con fixtures `.il` y snapshots (incluye casos de `stdin`).
-- [ ] Cross‑platform (Windows paths) probado.
+- [ ] Subcommand/flag documented in `--help`.
+- [ ] Human/JSON reporters consistent and tested.
+- [ ] Correct `exitCode` for error scenarios.
+- [ ] E2E tests with `.il` fixtures and snapshots (include `stdin`).
+- [ ] Cross-platform paths (Windows) checked.
 
-## Errores CLI (ILC04xx)
+## CLI errors (ILC04xx)
 
-- **ILC0401**: flag desconocido / combinación inválida.
-- **ILC0402**: archivo no encontrado o patrón vacío.
-- **ILC0403**: config inválida.
+- **ILC0401**: unknown flag or invalid combination.
+- **ILC0402**: file not found or empty pattern.
+- **ILC0403**: invalid config.

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -69,7 +69,7 @@ export async function runBuild(files: string[], flags: BuildFlags) {
     .filter(isIlFile)
     .map((f) => {
       const src = fs.readFileSync(f, "utf8");
-      if (/^\s*$/.test(src)) return null as any; // skip vacíos
+      if (/^\s*$/.test(src)) return null as any; // skip empty ones
       const program = parse(src);
       diagnostics.push(...checkProgram(program));
       return { file: f, program };

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -18,17 +18,17 @@ function isIlFile(p: string): boolean {
   }
 }
 
-// Header mínimo aceptado (case-insensitive, tolera espacios/EOL)
+// Minimal accepted header (case-insensitive, tolerates spaces/EOL)
 const MIN_HEADER_RE =
   /^\s*intent\s+"[^"]*"\s+tags\s*\[\]\s*(?:\r?\n)+\s*uses\s*{\s*}\s*(?:\r?\n)+\s*types\s*{\s*}\s*$/i;
 
-// ---------- globbing mínimo ----------
+// ---------- minimal globbing ----------
 const SEP = path.sep;
 const GLOB_RE = /[*?\[]/;
 const looksLikeGlob = (s: string) => GLOB_RE.test(s);
 
 function globToRegExp(glob: string): RegExp {
-  // Soporte: **, *, ?, escapado simple; normaliza a '/'
+    // Support: **, *, ?, simple escaping; normalize to '/'
   let re = glob.replace(/[.+^${}()|\\]/g, "\\$&");
   re = re.replace(/\*\*/g, "§§DS§§");
   re = re.replace(/\*/g, "[^/]*").replace(/\?/g, "[^/]");
@@ -110,7 +110,7 @@ function printWatchStatus(info: {
   );
 }
 
-// ---------- caché por archivo ----------
+// ---------- per-file cache ----------
 type CacheEntry = { mtimeMs: number; diags: Diagnostic[] };
 
 async function runOnce(filePatterns: string[], cache: Map<string, CacheEntry>) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -85,7 +85,7 @@ function parseCheck(rest: string[]): string[] {
   const looksLikeGlob = (s: string) => /[*?\[]/.test(s);
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i];
-    if (a.startsWith("-")) usage(); // en 'check' no hay flags específicas
+    if (a.startsWith("-")) usage(); // 'check' has no specific flags
     files.push(a);
   }
   if (files.length === 0) usage();

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,47 +1,47 @@
-# AGENTS.md — Guía del paquete **Core**
+# AGENTS.md — Core Package Guide
 
-**Ámbito**: AST, lexer, parser, checker, transpiler(s), runtime y `index.ts` público.
+**Scope**: AST, lexer, parser, checker, transpilers, runtime and public `index.ts`.
 
-## Principios
+## Principles
 
-- **Determinismo**: salidas estables, sin dependencia del reloj ni RNG (usa semillas del runtime).
-- **Fuente única de verdad**: el **AST** define capacidades del lenguaje; cualquier cambio en sintaxis, tipos o semántica empieza allí.
-- **Compatibilidad**: evoluciona con cambios _aditivos_; las rupturas requieren nota de migración y `minor` bump.
-- **Exhaustividad**: `match` y uniones deben tener cobertura total en checker y goldens.
+- **Determinism**: outputs must be stable, independent of clock or RNG (seed the runtime).
+- **Single source of truth**: the **AST** defines language capabilities; syntax, types and semantics changes start here.
+- **Compatibility**: evolve with additive changes; breaking changes require migration notes and a minor version bump.
+- **Exhaustiveness**: `match` and union types must be fully covered in the checker and goldens.
 
-## Responsabilidades del paquete
+## Package responsibilities
 
-- **`ast.ts`**: contratos de nodos y spans. Mantén **comentarios de versión** (v0.x) y _fields_ opcionales para crecer.
-- **`lexer.ts`**: tokens, comentarios, números (int/float), strings. No _logs_ en producción.
-- **`parser.ts`**: gramática recursiva, bloques, patrones. Sin efectos laterales.
-- **`checker.ts`**: símbolos, tipos internos, reglas de exhaustividad y capacidades. Emite **ILC02xx/ILC03xx**.
-- **`transpilers/typescript.ts`**: mapeo IL→TS determinista; prelude mínimo inline; orden fijo de propiedades.
-- **`runtime/`**: primitivos deterministas (`initRuntime`, RNG, clock). Super pequeño y estable.
+- **`ast.ts`**: node contracts and spans. Keep **version comments** (v0.x) and optional fields for growth.
+- **`lexer.ts`**: tokens, comments, numbers (int/float), strings. No production logs.
+- **`parser.ts`**: recursive grammar, blocks, patterns. No side effects.
+- **`checker.ts`**: symbols, internal types, exhaustiveness rules and capabilities. Emit **ILC02xx/ILC03xx**.
+- **`transpilers/typescript.ts`**: IL→TS deterministic mapping; inline minimal prelude; fixed property order.
+- **`runtime/`**: deterministic primitives (`initRuntime`, RNG, clock). Tiny and stable.
 
-## Flujo de cambio
+## Change flow
 
-1. **Diseño**: si afecta semántica/sintaxis → abre RFC.
-2. **AST**: añade nodos/campos opcionales; no rompas existentes si puedes evitarlo.
-3. **Lexer/Parser**: añade tokens y reglas juntas; incluye tests de error y recuperación.
-4. **Checker**: crea/usa códigos **ILC000x** nuevos; redacta mensajes con snippet y caret.
-5. **Transpiler**: garantiza idempotencia y orden estable; ajusta goldens.
-6. **Runtime**: documenta cualquier nueva primitiva.
+1. **Design**: if it affects semantics or syntax → open an RFC.
+2. **AST**: add nodes/optional fields; avoid breaking existing ones when possible.
+3. **Lexer/Parser**: add tokens and rules together; include error and recovery tests.
+4. **Checker**: create/use new `ILC000x` codes; write messages with snippet and caret.
+5. **Transpiler**: ensure determinism and stable ordering; adjust goldens.
+6. **Runtime**: document any new primitive.
 
-## Checklist de PR (Core)
+## PR checklist (Core)
 
-- [ ] `pnpm -w build` sin errores.
-- [ ] `ilc check` a repo de ejemplos (si aplica) sin errores.
-- [ ] Tests de lexer/parser/checker/transpiler añadidos.
-- [ ] `ilc goldens run` sin diffs (o `update` justificado).
-- [ ] Nuevos códigos ILC documentados y `--explain` actualizado.
-- [ ] Sin `console.*` ni dependencias nuevas sin justificación.
+- [ ] `pnpm -w build` passes.
+- [ ] `ilc check` on examples (if touched) passes.
+- [ ] Tests for lexer/parser/checker/transpiler added.
+- [ ] `ilc goldens run` passes (or justified `update`).
+- [ ] New ILC codes documented and `--explain` updated.
+- [ ] No `console.*` or new dependencies without justification.
 
-## Códigos de diagnóstico sugeridos
+## Suggested diagnostic codes
 
-- **ILC010x**: léxico/parsing (token inesperado, string sin cierre, etc.).
-- **ILC020x**: tipos/exhaustividad (match no exhaustivo, tipos incompatibles).
-- **ILC030x**: capacidades/efectos (uso en contexto puro, capability no declarada).
+- **ILC010x**: lexing/parsing (unexpected token, unterminated string, etc.).
+- **ILC020x**: typing/exhaustiveness (non-exhaustive match, incompatible types).
+- **ILC030x**: capabilities/effects (effect used in pure context, undeclared capability).
 
-## Rendimiento
+## Performance
 
-- Mide con `--trace`; evita regresiones >10% en ejemplos medianos. Si sucede, explica causa/mitigación.
+- Measure with `--trace`; avoid >10% regressions on medium examples. Explain cause/mitigation if it occurs.

--- a/packages/core/grammar/intentlang.ebnf
+++ b/packages/core/grammar/intentlang.ebnf
@@ -1,19 +1,19 @@
 (* ---------- Lexical ---------- *)
-UpperLetter     = ? una letra mayúscula de 'A' a 'Z' ? ;
-LowerLetter     = ? una letra minúscula de 'a' a 'z' ? ;
-DigitChar       = ? un dígito de '0' a '9' ? ;
+UpperLetter     = ? an uppercase letter from 'A' to 'Z' ? ;
+LowerLetter     = ? a lowercase letter from 'a' to 'z' ? ;
+DigitChar       = ? a digit from '0' to '9' ? ;
 
 letter          = UpperLetter | LowerLetter | "_" ;
 digit           = DigitChar ;
 ident           = letter , { letter | digit } ;
 
-string          = '"' , { ? cualquier carácter de string, incluyendo escapes ? } , '"' ;
+string          = '"' , { ? any string character, including escapes ? } , '"' ;
 int             = ["-"] , digit , { digit } ;
 float           = ["-"] , digit , { digit } , "." , digit , { digit } ;
 bool            = "true" | "false" ;
 
-comment         = "//" , { ? cualquier carácter hasta el final de la línea ? }
-                | "/*" , { ? cualquier carácter hasta encontrar "*/" ? } ;
+comment         = "//" , { ? any character until end of line ? }
+                | "/*" , { ? any character until "*/" ? } ;
 ws              = { " " | "\t" | "\r" | "\n" | comment } ;
 
 

--- a/packages/core/src/ast.ts
+++ b/packages/core/src/ast.ts
@@ -1,5 +1,5 @@
 // packages/core/src/ast.ts
-// AST v0.2 — añade Expr/Stmt/Pattern y cuerpos reales en func/effect
+// AST v0.2 — adds Expr/Stmt/Pattern and real bodies in func/effect
 
 export type Position = { line: number; column: number; index: number };
 export type Span = { start: Position; end: Position };
@@ -92,7 +92,7 @@ export type RecordType = {
   span: Span;
 };
 
-// Uniones: constructores nombrados o literales (p.ej. "EUR")
+// Unions: named constructors or literals (e.g. "EUR")
 export type UnionCtor =
   | { kind: "NamedCtor"; name: Identifier; fields?: RecordType; span: Span }
   | { kind: "LiteralCtor"; literal: LiteralType; span: Span };
@@ -125,7 +125,7 @@ export type FuncDecl = {
   params: ParamSig[];
   returnType: TypeExpr;
   contracts?: { requires?: Expr; ensures?: Expr };
-  body: Block; // v0.2: cuerpo real
+  body: Block; // v0.2: real body
   span: Span;
 };
 
@@ -135,8 +135,8 @@ export type EffectDecl = {
   params: ParamSig[];
   returnType: TypeExpr;
   contracts?: { requires?: Expr; ensures?: Expr };
-  uses: Identifier[]; // capacidades requeridas
-  body: Block; // v0.2: cuerpo real
+  uses: Identifier[]; // required capabilities
+  body: Block; // v0.2: real body
   span: Span;
 };
 

--- a/packages/core/src/checker.ts
+++ b/packages/core/src/checker.ts
@@ -478,7 +478,7 @@ function checkStmt(ctx: Ctx, f: FlowCtx, s: Stmt) {
   }
 }
 
-/* Expr typing (mínimo útil) */
+/* Expr typing (minimal useful) */
 function inferExpr(ctx: Ctx, f: FlowCtx, e: Expr): T {
   switch (e.kind) {
     case "LiteralExpr":

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -266,7 +266,7 @@ export function parse(input: string): Program {
   function tryParseUnionType(): UnionType | null {
     const save = p;
 
-    // ¿Hay tubería inicial?
+    // Is there a leading pipe?
     const leading = !!eat("pipe");
 
     // --- Uniones de literales ---
@@ -842,22 +842,22 @@ export function parse(input: string): Program {
       span: Span;
     }[] = [];
 
-    // Campos (posiblemente vacíos)
+    // Fields (possibly empty)
     while (!peek("rbrace")) {
-      // Si por alguna razón vemos otra '{' aquí, la tratamos como apertura de objeto
-      // interno del valor, pero eso solo puede aparecer después de "clave:".
-      // Para robustez, si aparece una '{' antes de una clave, hacemos un pequeño
-      // “sync” consumiendo hasta la próxima '}' y continuamos (evita loops).
+      // If we somehow see another '{' here, treat it as the start of an inner object
+      // inside the value, but that can only appear after "key:".
+      // For robustness, if a '{' appears before a key we do a small
+      // "sync" consuming up to the next '}' and continue (avoids loops).
       if (peek("lbrace")) {
-        // recuperación suave: consumimos un bloque-objeto y seguimos
-        // (esto no debería ocurrir en entradas válidas).
+        // soft recovery: consume an object block and continue
+        // (this should not happen in valid inputs).
         let depth = 0;
         do {
           if (eat("lbrace")) depth++;
           else if (eat("rbrace")) depth--;
-          else p++; // avanzamos token a token
+          else p++; // move token by token
         } while (depth > 0 && !atEnd());
-        // si después de esto viene una coma, la comemos
+        // if a comma follows, consume it
         eat("comma");
         continue;
       }
@@ -906,7 +906,7 @@ export function parse(input: string): Program {
 
     const cases: CaseClause[] = [];
     while (!peek("rbrace")) {
-      // activar inPattern SOLO para el patrón
+      // enable inPattern ONLY for the pattern
       const prev = inPattern;
       inPattern = true;
       const pat = parsePattern();

--- a/packages/core/src/transpilers/typescript.ts
+++ b/packages/core/src/transpilers/typescript.ts
@@ -133,7 +133,7 @@ function basicToTs(b: BasicType): string {
     case "Uuid":
       return "string";
     case "DateTime":
-      // Puedes cambiarlo a string si prefieres —en goldens lo usáis como Date o string indistintamente.
+      // You can change it to string if you prefer—in goldens it's used as Date or string interchangeably.
       return "Date";
   }
 }
@@ -146,7 +146,7 @@ function recordToTs(r: RecordType): string {
 }
 
 function unionToTs(u: TypeExpr & { kind: "UnionType" }): string {
-  // Convención de IL: unions discriminadas por `type: "<Ctor>"`
+  // IL convention: unions discriminated by `type: "<Ctor>"`
   // Literal unions: string|number|boolean literales
   const parts = u.ctors.map((c) => {
     if (c.kind === "LiteralCtor") {
@@ -161,7 +161,7 @@ function unionToTs(u: TypeExpr & { kind: "UnionType" }): string {
         : "";
     return `{ type: "${name}"${payload}}`;
   });
-  // Si hay mezcla de literales y nombrados, TS quedará como unión heterogénea.
+  // If literals and named constructors are mixed, TS becomes a heterogeneous union.
   return parts.join(" | ");
 }
 
@@ -308,7 +308,7 @@ function emitLiteral(e: LiteralExpr): string {
 }
 
 function emitCall(c: CallExpr, isEffect: boolean): string {
-  // Caso más útil: llamada a capacidad → deps.<cap>.<method>(...)
+  // Most useful case: capability call → deps.<cap>.<method>(...)
   if (c.callee.kind === "MemberExpr") {
     const obj = c.callee.object;
     const prop = c.callee.property.name;
@@ -420,7 +420,7 @@ function emitCasesAsIfs(
       `${idx === 0 ? "if" : "else if"} (${cond}) {\n${indent(body)}\n}`,
     );
   });
-  // Nota: el checker asegura exhaustividad; aquí no añadimos else.
+  // Note: the checker ensures exhaustiveness; we do not add an else here.
   return parts.join("\n");
 }
 

--- a/packages/examples/AGENTS.md
+++ b/packages/examples/AGENTS.md
@@ -1,14 +1,14 @@
-# AGENTS.md — Guía del paquete **Examples & Goldens**
+# AGENTS.md — Examples & Goldens
 
-**Ámbito**: ejemplos canónicos `.il`, goldens `.ts`, runner de comparaciones y prelude TS.
+**Scope**: canonical `.il` examples, `.ts` golden files, comparison runner and TS prelude.
 
-## Principios
+## Principles
 
-- **Contrato público** del transpiler: los goldens definen la salida esperada.
-- **Determinismo**: encabezado/prelude común; sin fechas ni aleatoriedad sin seed.
-- **Paridad**: cada `*.il` tiene su `goldens/*.ts` correspondiente.
+- **Public contract** of the transpiler: goldens define the expected output.
+- **Determinism**: shared header/prelude; no dates or randomness without a seed.
+- **Parity**: each `*.il` has a corresponding `goldens/*.ts` file.
 
-## Estructura
+## Structure
 
 ```tree
 packages/examples/
@@ -28,23 +28,23 @@ packages/examples/
     goldens.mjs
 ```
 
-## Flujo para añadir/actualizar un ejemplo
+## Flow to add/update an example
 
-1. Crear `<feature>.il` minimal y legible.
-2. Ejecutar `ilc build <feature>.il --target ts` para ver salida.
-3. Copiar salida + `_prelude.ts` al golden equivalente.
-4. Correr `ilc goldens run`.
-5. Si el cambio es intencional, `ilc goldens update --only <feature>` y abre PR.
+1. Create a minimal, readable `<feature>.il`.
+2. Run `ilc build <feature>.il --target ts` to see the output.
+3. Copy the output plus `_prelude.ts` to the matching golden file.
+4. Run `ilc goldens run`.
+5. If intentional, accept changes with `ilc goldens update --only <feature>` and open a PR.
 
-## Checklist de PR (Examples)
+## PR checklist (Examples)
 
-- [ ] Ejemplo `.il` idiomático y con comentarios breves.
-- [ ] Golden actualizado y válido (compila como TS).
-- [ ] No usa dependencias externas; solo el prelude.
-- [ ] Runner de goldens pasa en CI.
+- [ ] Idiomatic `.il` example with brief comments.
+- [ ] Golden updated and valid (compiles as TS).
+- [ ] No external dependencies; only the prelude.
+- [ ] Golden runner passes in CI.
 
-## Buenas prácticas
+## Best practices
 
-- Nombres consistentes (`Email`, `UserId`, `PaymentId`).
-- `match` exhaustivos en ejemplos de uniones.
-- Inputs y outputs simples; evita lógica de negocio innecesaria.
+- Consistent names (`Email`, `UserId`, `PaymentId`).
+- Exhaustive `match` for union examples.
+- Simple inputs and outputs; avoid unnecessary business logic.

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -39,7 +39,7 @@ To add a new canonical example and its golden test:
 
 ## Current Examples
 
-- **add.il**: muestra `test`, contratos y capacidades con semillas.
+- **add.il**: showcases `test`, contracts, and capabilities with seeds.
 - **/user/**: Basic CRUD operations, brands, and records.
 - **/order/**: Usage of multiple capabilities (`http`, `clock`, `random`).
 - **/invoice/**: Complex record structures and multiple pure `func` helpers.


### PR DESCRIPTION
### Motivation
Make the codebase and documentation accessible to non‑Spanish speakers.

### Changes
- Translate AGENTS guidelines, docs and changelog to English
- Convert grammar and source comments to English in core and CLI
- Update examples README and remaining comments

### Risks and mitigations
- Translation might slightly change nuance; reviewed text to preserve original meaning.
- No functional changes; builds and tests ensure integrity.

### Testing
- `pnpm -w build`
- `pnpm -w typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm --filter @il/examples test:goldens` *(fails: Expected ident, got kw_return at 6:9)*

------
https://chatgpt.com/codex/tasks/task_e_68a50ffe485083328875be5dbbcff52d