### PR TITLE
feat(cli): add stdin support for check

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Features
 
 - **check:** limit printed errors with `--max-errors` and show truncation summary.
+- **check:** accept `-` to read from stdin and label diagnostics as `(stdin)`.
 
 ## [1.3.0](https://github.com/alessbarb/IntentLang/compare/@il/cli-v1.2.0...@il/cli-v1.3.0) (2025-08-19)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -10,6 +10,8 @@ pnpm --filter @il/cli ilc check path/to/file.il
 pnpm --filter @il/cli ilc build path/to/file.il --target ts --out dist
 # Watch mode (revalidate on save)
 pnpm --filter @il/cli ilc check "src/**/*.il" --watch --max-errors 50
+# Read from stdin
+cat path/to/file.il | pnpm --filter @il/cli ilc check -
 ```
 
 `ilc check` prints `OK` when the file typechecks, exits with code `1` on

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -85,10 +85,15 @@ function parseCheck(rest: string[]): string[] {
   const looksLikeGlob = (s: string) => /[*?\[]/.test(s);
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i];
-    if (a.startsWith("-")) usage(); // 'check' has no specific flags
-    files.push(a);
+    if (a === "-") files.push(a);
+    else if (a.startsWith("-")) usage(); // 'check' has no specific flags
+    else files.push(a);
   }
   if (files.length === 0) usage();
+  if (files.includes("-")) {
+    if (files.length > 1) usage();
+    return ["-"];
+  }
   // Permite globs/directorios; solo exige existencia cuando no parece glob
   if (files.some((f) => !looksLikeGlob(f) && !fs.existsSync(f))) usage();
   return files;


### PR DESCRIPTION
## Summary
- allow `ilc check -` to read code from stdin
- label diagnostics from stdin as `(stdin)` in both human and JSON output
- document stdin usage

## Testing
- `pnpm --filter @il/cli build`
- `pnpm --filter @il/cli test`


------
https://chatgpt.com/codex/tasks/task_e_68a57fa562b483329670ec0fab26ba1e