### PR TITLE
build(examples): generate dataset on build

### DIFF
--- a/docs/examples-dataset.md
+++ b/docs/examples-dataset.md
@@ -14,13 +14,19 @@ If the file transpiles successfully, copy the output to `packages/examples/golde
 
 ## 2. Generate the dataset
 
-Use the helper script to export `{source_il, transpiled_ts, ast}` triples in JSON Lines format:
+The dataset is generated during the workspace build. Run:
 
 ```bash
-node packages/examples/scripts/export-dataset.mjs
+pnpm -w build
 ```
 
-This creates `packages/examples/dataset.jsonl` with one JSON object per line. Entries without goldens are skipped and files that fail to parse will have `ast: null`.
+This writes `{source_il, transpiled_ts, ast}` triples to `packages/examples/dataset.jsonl`. Entries without goldens are skipped and files that fail to parse will have `ast: null`.
+
+To regenerate just the dataset after other packages are built, run:
+
+```bash
+pnpm --filter @il/examples build
+```
 
 ## 3. Next steps
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.0",
   "private": true,
   "scripts": {
+    "build": "node ./scripts/export-dataset.mjs",
     "test:goldens": "node ./scripts/goldens.mjs",
     "test:goldens:update": "UPDATE=1 node ./scripts/goldens.mjs"
   },


### PR DESCRIPTION
## Summary
- regenerate examples dataset as part of the build step
- document automatic dataset export via workspace build

## Testing
- `pnpm -w build`
- `pnpm -w typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a582efa0fc83329a936efe259205b7