### PR TITLE
docs: index package guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,14 @@
 - Before opening a PR: update EBNF/lexer/parser together, run golden tests, add tests.
 - Never commit secrets or make unapproved network calls. Escalate to a human if unsure.
 
+## Package-specific guides
+
+This root guide is the primary source of truth. The following documents add rules for specific areas:
+
+- [Core package guide](packages/core/AGENTS.md)
+- [CLI package guide](packages/cli/AGENTS.md)
+- [Examples & goldens guide](packages/examples/AGENTS.md)
+
 ---
 
 ## 1) Repository context

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md — CLI Package (`ilc`)
 
+Refer first to the [repository-wide guide](../../AGENTS.md). This file covers CLI-specific rules.
+
 **Scope**: binary, flag parsing, human/JSON reporting, exit codes and UX.
 
 ## Principles

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md — Core Package Guide
 
+Refer first to the [repository-wide guide](../../AGENTS.md). This file adds rules specific to the core package.
+
 **Scope**: AST, lexer, parser, checker, transpilers, runtime and public `index.ts`.
 
 ## Principles

--- a/packages/examples/AGENTS.md
+++ b/packages/examples/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md — Examples & Goldens
 
+Refer first to the [repository-wide guide](../../AGENTS.md). This file describes rules for examples and goldens.
+
 **Scope**: canonical `.il` examples, `.ts` golden files, comparison runner and TS prelude.
 
 ## Principles


### PR DESCRIPTION
## Summary
- index package-level AGENTS guides from root AGENTS
- cross-link package AGENTS files back to repo-wide guide

## Testing
- `pnpm -w build`
- `pnpm -w typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a5c9f1822c83328ba570f0e0da2218