### PR TITLE
test: cover diagnostic reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased]
+
+### Docs
+
+- document diagnostic codes and message templates.
+
+### Tests
+
+- add golden tests for human and JSON diagnostic output.
+
 ## [1.10.0](https://github.com/alessbarb/IntentLang/compare/v1.9.0...v1.10.0) (2025-08-20)
 
 ### Features

--- a/docs/reference/diagnostics.md
+++ b/docs/reference/diagnostics.md
@@ -1,0 +1,37 @@
+# Diagnostic codes
+
+IntentLang uses stable codes `ILC000x` for all diagnostics. The table below maps each code to its message template. Placeholders in `{}` are filled with context when reported.
+
+| Code | Message |
+| --- | --- |
+| ILC0201 | Duplicate type '{type}'. |
+| ILC0202 | Unknown type '{type}'. |
+| ILC0203 | Mixed literal and named constructors in union. Prefer a single style. |
+| ILC0204 | Duplicate constructor '{ctor}' in union. |
+| ILC0205 | '{kind}' must be Bool. Got {type}. |
+| ILC0206 | Unknown function or effect '{name}' in test. |
+| ILC0207 | Return type mismatch: got {got}, expected {expected}. |
+| ILC0208 | If condition must be Bool. Got {type}. |
+| ILC0209 | Unknown identifier '{name}'. |
+| ILC0210 | Cannot resolve call target. |
+| ILC0211 | '!' expects Bool. Got {type}. |
+| ILC0212 | Unary '-' expects Number. Got {type}. |
+| ILC0213 | Logical '{op}' expects Bool operands. |
+| ILC0214 | '{op}' requires comparable operands. Got {left} and {right}. |
+| ILC0215 | Relational '{op}' expects Number operands. |
+| ILC0216 | Arithmetic '{op}' expects Number operands. |
+| ILC0217 | Function '{name}' expects {expected} argument(s), got {got}. |
+| ILC0218 | Argument {index} of '{name}' mismatch: got {got}, expected {expected}. |
+| ILC0219 | Pattern must be a named constructor for this union. |
+| ILC0220 | Unknown case '{ctor}' for union. Did you mean '{suggestion}'? |
+| ILC0221 | Unreachable duplicate case for constructor '{ctor}'. |
+| ILC0222 | Constructor '{ctor}' has no field '{field}'. |
+| ILC0223 | In a 'match' used as an expression, each case must be an expression (not a block). |
+| ILC0224 | Non-exhaustive match. Missing: {missing}. |
+| ILC0225 | Pattern must be a literal for this union. |
+| ILC0226 | Unknown literal case '{literal}'. Did you mean '{suggestion}'? |
+| ILC0227 | Unreachable duplicate case for literal '{literal}'. |
+| ILC0228 | 'match' on non-union type {type} — exhaustiveness not enforced. |
+| ILC0301 | Effect '{effect}' lists undeclared capability '{cap}'. Add it to 'uses { ... }'. |
+| ILC0302 | Pure function '{func}' cannot use capability '{cap}'. |
+| ILC0303 | Effect '{effect}' uses capability '{cap}' but it is not listed in 'uses' for this effect. |

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -38,6 +38,10 @@
 - **check:** accept `-` to read from stdin and label diagnostics as `(stdin)`.
 - **check:** cross-platform globbing; exit `2` when no files match.
 
+### Tests
+
+- cover diagnostic reporter with human and JSON snapshots.
+
 ## [1.3.0](https://github.com/alessbarb/IntentLang/compare/@il/cli-v1.2.0...@il/cli-v1.3.0) (2025-08-19)
 
 ### Features

--- a/packages/cli/tests/diagnostics-output.test.ts
+++ b/packages/cli/tests/diagnostics-output.test.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+spawnSync("pnpm", ["--filter", "@il/core", "build"], {
+  cwd: repoRoot,
+  stdio: "inherit",
+});
+spawnSync("pnpm", ["--filter", "@il/cli", "build"], {
+  cwd: repoRoot,
+  stdio: "inherit",
+});
+
+const cliPath = fileURLToPath(new URL("../dist/index.js", import.meta.url));
+
+test("diagnostics include snippet with caret and stable code", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "ilc-diag-"));
+  const file = join(tmp, "bad.il");
+  writeFileSync(file, `intent "X" tags []\nuses {}\ntypes {}\neffect boom(): Int uses http {}\n`);
+
+  const resHuman = spawnSync("node", [cliPath, "check", file, "--no-color"], {
+    encoding: "utf8",
+  });
+  expect(resHuman.status).toBe(1);
+  expect(resHuman.stderr).not.toMatch(/\x1b\[/);
+  expect(resHuman.stderr).toContain("ILC0301");
+  expect(resHuman.stderr).toContain("bad.il:4:7");
+  expect(resHuman.stderr).toContain("effect boom(): Int uses http {}");
+  expect(resHuman.stderr).toContain("^");
+
+  const resJson = spawnSync("node", [cliPath, "check", file, "--json"], {
+    encoding: "utf8",
+  });
+  expect(resJson.status).toBe(1);
+  const json = JSON.parse(resJson.stdout);
+  const norm = file.replace(/\\/g, "/");
+  json.diagnostics[0].file = json.diagnostics[0].file.replace(norm, "<tmp>/bad.il");
+  json.diags[0].file = json.diags[0].file.replace(norm, "<tmp>/bad.il");
+  expect(json).toEqual({
+    kind: "check",
+    meta: { strict: false, watch: false },
+    counts: { errors: 1, warnings: 0 },
+    diagnostics: [
+      {
+        level: "error",
+        code: "ILC0301",
+        message:
+          "Effect 'boom' lists undeclared capability 'http'. Add it to 'uses { ... }'.",
+        span: {
+          start: { line: 4, column: 7, index: 42 },
+          end: { line: 4, column: 7, index: 42 },
+        },
+        file: "<tmp>/bad.il",
+      },
+    ],
+    status: "error",
+    diags: [
+      {
+        level: "error",
+        code: "ILC0301",
+        message:
+          "Effect 'boom' lists undeclared capability 'http'. Add it to 'uses { ... }'.",
+        span: {
+          start: { line: 4, column: 7, index: 42 },
+          end: { line: 4, column: 7, index: 42 },
+        },
+        file: "<tmp>/bad.il",
+      },
+    ],
+    exitCode: 1,
+  });
+
+  rmSync(tmp, { recursive: true, force: true });
+});

--- a/packages/cli/tests/ilc-check.test.ts
+++ b/packages/cli/tests/ilc-check.test.ts
@@ -24,7 +24,7 @@ test("ilc check command", () => {
 
   let res = spawnSync("node", [cliPath, "check", valid], { encoding: "utf8" });
   expect(res.status).toBe(0);
-  expect(res.stdout).toMatch(/OK/);
+  expect(res.stdout).toMatch(/Check passed/);
 
   const bad = join(tmp, "bad.il");
   writeFileSync(
@@ -86,7 +86,7 @@ test("--max-errors truncates errors output", () => {
   const stderr = res.stderr;
   const errs = stderr.match(/undeclared capability 'http'/g) ?? [];
   expect(errs).toHaveLength(2);
-  expect(stderr).toMatch(/\+1 errors not shown/);
+  expect(stderr).toMatch(/\+1 more error\(s\) not shown\./);
   rmSync(tmp, { recursive: true, force: true });
 });
 
@@ -97,7 +97,7 @@ test("stdin support", () => {
     input: srcValid,
   });
   expect(res.status).toBe(0);
-  expect(res.stdout).toMatch(/OK/);
+  expect(res.stdout).toMatch(/Check passed/);
 
   const srcInvalid =
     `intent "X" tags []\nuses {}\ntypes {}\neffect boom(): Int uses http {}`;
@@ -143,7 +143,7 @@ test("globbing is cross-platform and reports missing matches", () => {
   expect(res.status).toBe(1);
   const normalized = `<tmp>/${res.stderr}`;
   expect(normalized).toMatchInlineSnapshot(
-    `"<tmp>/src/sub/bad.il: [ERROR] Effect 'boom' lists undeclared capability 'http'. Add it to 'uses { ... }'. at 4:7\n"`,
+    `"<tmp>/\n-- ERROR (ILC0301) --------------------------------------------------\n\nEffect 'boom' lists undeclared capability 'http'. Add it to 'uses { ... }'.\n\n  --> bad.il:4:7\n\n4 | effect boom(): Int uses http {}\n         ^\n\nCheck failed with 1 error(s).\n"`,
   );
 
   // quoted glob

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -125,7 +125,7 @@ export const DIAGNOSTICS = {
   ILC0301: {
     level: "error",
     message:
-      "Effect '{effect}' lists undeclared capability '{cap}'. Add it to 'uses {{ ... }}'.",
+      "Effect '{effect}' lists undeclared capability '{cap}'. Add it to 'uses { ... }'.",
   },
   ILC0302: {
     level: "error",


### PR DESCRIPTION
## Summary
- document diagnostic codes
- cover diagnostic reporter with human and JSON tests

## Testing
- `pnpm -w build`
- `pnpm -w typecheck`
- `pnpm -w test` *(fails: Expected ident, got fat_arrow at 11:26)*
- `pnpm --filter @il/cli test`


------
https://chatgpt.com/codex/tasks/task_e_68a608ae65948332a320880a808fda78