### PR TITLE
feat(core): add for/in keywords to lexer

### DIFF
--- a/packages/core/src/lexer.ts
+++ b/packages/core/src/lexer.ts
@@ -25,6 +25,8 @@ export type Token = {
     | "kw_None"
     | "kw_brand"
     | "kw_test"
+    | "kw_for"
+    | "kw_in"
     | "ident"
     | "string"
     | "number"
@@ -86,6 +88,8 @@ const KEYWORDS = new Map<string, Token["type"]>([
   ["None", "kw_None"],
   ["brand", "kw_brand"],
   ["test", "kw_test"],
+  ["for", "kw_for"],
+  ["in", "kw_in"],
 ]);
 
 export function lex(input: string): Token[] {

--- a/packages/core/tests/lexer.test.ts
+++ b/packages/core/tests/lexer.test.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "vitest";
+import { lex } from "../src/lexer.js";
+
+test("lexes for-in loop keywords", () => {
+  const tokens = lex("for x in xs {}");
+  expect(tokens[0].type).toBe("kw_for");
+  expect(tokens[2].type).toBe("kw_in");
+});


### PR DESCRIPTION
## Summary
- recognize `for` and `in` as keywords in the lexer
- cover lexer with a test verifying `for`/`in` tokens

## Testing
- `pnpm -w build`
- `pnpm -w typecheck`
- `pnpm -w test` *(fails: Expected ident, got fat_arrow... Expected string, got lparen...)*
- `pnpm ilc fmt packages/core/src/lexer.ts` *(fails: Usage: ilc <check|build|test> ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a7112dfc7483328d53e9026e8aacf3