### PR TITLE
feat(core): add for statement parsing

### DIFF
--- a/docs/grammar/EBNF.md
+++ b/docs/grammar/EBNF.md
@@ -113,12 +113,13 @@ ContractBlock   = [ "requires" , Expr ] , [ "ensures" , Expr ] ;
 
 ```ebnf
 Block           = "{" , ws , { Stmt } , "}" ;
-Stmt            = LetStmt | ReturnStmt | IfStmt | MatchStmt | ExprStmt ;
+Stmt            = LetStmt | ReturnStmt | IfStmt | MatchStmt | ForStmt | ExprStmt ;
 
 LetStmt         = "let" , ident , "=" , Expr , [";"] ;
 ReturnStmt      = "return" , [ Expr ] , [";"] ;
 IfStmt          = "if" , Expr , Block , [ "else" , Block ] ;
 MatchStmt       = MatchExpr , [";"] ;
+ForStmt         = "for" , ident , "in" , Expr , Block ;
 ExprStmt        = Expr , [";"] ;
 ```
 

--- a/packages/core/grammar/intentlang.ebnf
+++ b/packages/core/grammar/intentlang.ebnf
@@ -90,12 +90,13 @@ ContractBlock   = [ "requires" , Expr ] , [ "ensures" , Expr ] ;
 
 (* ---------- Statements & Blocks ---------- *)
 Block           = "{" , ws , { Stmt } , "}" ;
-Stmt            = LetStmt | ReturnStmt | IfStmt | MatchStmt | ExprStmt ;
+Stmt            = LetStmt | ReturnStmt | IfStmt | MatchStmt | ForStmt | ExprStmt ;
 
 LetStmt         = "let" , ident , "=" , Expr , [";"] ;
 ReturnStmt      = "return" , [ Expr ] , [";"] ;
 IfStmt          = "if" , Expr , Block , [ "else" , Block ] ;
 MatchStmt       = MatchExpr , [";"] ;
+ForStmt         = "for" , ident , "in" , Expr , Block ;
 ExprStmt        = Expr , [";"] ;
 
 

--- a/packages/core/src/ast.ts
+++ b/packages/core/src/ast.ts
@@ -168,7 +168,13 @@ export type Block = { kind: "Block"; statements: Stmt[]; span: Span };
 
 export type TestBlock = { kind: "TestBlock"; statements: Stmt[]; span: Span };
 
-export type Stmt = LetStmt | ReturnStmt | IfStmt | MatchStmt | ExprStmt;
+export type Stmt =
+  | LetStmt
+  | ReturnStmt
+  | IfStmt
+  | MatchStmt
+  | ForStmt
+  | ExprStmt;
 
 export type LetStmt = {
   kind: "LetStmt";
@@ -188,6 +194,13 @@ export type MatchStmt = {
   kind: "MatchStmt";
   expr: Expr;
   cases: CaseClause[];
+  span: Span;
+};
+export type ForStmt = {
+  kind: "ForStmt";
+  id: Identifier;
+  iterable: Expr;
+  body: Block;
   span: Span;
 };
 export type ExprStmt = { kind: "ExprStmt"; expression: Expr; span: Span };

--- a/packages/core/src/checker.ts
+++ b/packages/core/src/checker.ts
@@ -27,6 +27,7 @@ import type {
   VariantPattern,
   LiteralPattern,
   MatchStmt,
+  ForStmt,
 } from "./ast.js";
 import { DIAGNOSTICS } from "./diagnostics.js";
 
@@ -446,6 +447,13 @@ function checkStmt(ctx: Ctx, f: FlowCtx, s: Stmt) {
     }
     case "MatchStmt": {
       checkMatchFromStmt(ctx, f, s);
+      return;
+    }
+    case "ForStmt": {
+      inferExpr(ctx, f, s.iterable);
+      const scope = new Map(f.scope);
+      scope.set(s.id.name, TUnknown);
+      checkBlock(ctx, { ...f, scope }, s.body);
       return;
     }
     case "ExprStmt": {

--- a/packages/core/src/lexer.ts
+++ b/packages/core/src/lexer.ts
@@ -17,6 +17,8 @@ export type Token = {
     | "kw_if"
     | "kw_else"
     | "kw_match"
+    | "kw_for"
+    | "kw_in"
     | "kw_true"
     | "kw_false"
     | "kw_Ok"
@@ -78,6 +80,8 @@ const KEYWORDS = new Map<string, Token["type"]>([
   ["if", "kw_if"],
   ["else", "kw_else"],
   ["match", "kw_match"],
+  ["for", "kw_for"],
+  ["in", "kw_in"],
   ["true", "kw_true"],
   ["false", "kw_false"],
   ["Ok", "kw_Ok"],

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -27,6 +27,7 @@ import {
   type ReturnStmt,
   type IfStmt,
   type MatchStmt,
+  type ForStmt,
   type ExprStmt,
   type Expr,
   type Literal,
@@ -512,6 +513,7 @@ export function parse(input: string): Program {
     if (peek("kw_return")) return parseReturnStmt();
     if (peek("kw_if")) return parseIfStmt();
     if (peek("kw_match")) return parseMatchStmt();
+    if (peek("kw_for")) return parseForStmt();
     const expr = parseExpr();
     eat("semi");
     return { kind: "ExprStmt", expression: expr, span: spanHere() };
@@ -554,6 +556,16 @@ export function parse(input: string): Program {
     const m = parseMatchExpr();
     eat("semi");
     return { kind: "MatchStmt", expr: m.expr, cases: m.cases, span: s };
+  }
+
+  function parseForStmt(): ForStmt {
+    const s = spanHere();
+    expect("kw_for");
+    const id = parseIdent();
+    expect("kw_in");
+    const iterable = parseExpr();
+    const body = parseBlock();
+    return { kind: "ForStmt", id, iterable, body, span: s };
   }
 
   /* ========= Expressions ========= */

--- a/packages/core/src/transpilers/typescript.ts
+++ b/packages/core/src/transpilers/typescript.ts
@@ -22,6 +22,7 @@ import type {
   ReturnStmt,
   IfStmt,
   MatchStmt,
+  ForStmt,
   ExprStmt,
   Expr,
   IdentifierExpr,
@@ -245,6 +246,11 @@ function emitStmt(s: Stmt, isEffect: boolean, ensures?: Expr): string {
     }
     case "MatchStmt": {
       return emitMatchStmt(s, isEffect, ensures);
+    }
+    case "ForStmt": {
+      const iter = emitExpr(s.iterable, isEffect);
+      const body = emitBlock(s.body, isEffect, ensures);
+      return `for (const ${s.id.name} of ${iter}) {\n${indent(body)}\n}`;
     }
     case "ExprStmt": {
       return `${emitExpr(s.expression, isEffect)};`;

--- a/packages/core/tests/for-stmt.test.ts
+++ b/packages/core/tests/for-stmt.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "vitest";
+import { parse } from "../src/parser.js";
+import { check } from "../src/checker.js";
+
+// Ensure the parser recognizes 'for' statements.
+test("parses for statements", () => {
+  const il = `
+    test loop {
+      for x in [1,2] { x; }
+    }
+  `;
+  const program = parse(il);
+  const diags = check(program);
+  expect(diags).toHaveLength(0);
+  const t = program.items.find((i) => i.kind === "TestDecl");
+  expect(t).toBeTruthy();
+  const stmt = t?.body.statements[0];
+  expect(stmt?.kind).toBe("ForStmt");
+  if (stmt?.kind === "ForStmt") {
+    expect(stmt.id.name).toBe("x");
+  }
+});


### PR DESCRIPTION
## Summary
- parse `for <id> in <expr>` blocks
- wire into checker and TypeScript emitter
- document `ForStmt` in EBNF and add parser test

## Testing
- `pnpm -w build`
- `pnpm -w typecheck`
- `pnpm run ilc fmt packages/core/src/parser.ts` *(fails: Usage: ilc <check|build|test>)*
- `pnpm run test:core` *(fails: Expected ident, got fat_arrow at 11:26)*
- `pnpm --filter @il/core test tests/for-stmt.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a711327a04833280b07a5dbd7e25e1