### PR TITLE
feat(core): emit for loops in python transpiler

### DIFF
--- a/packages/core/src/transpilers/python.ts
+++ b/packages/core/src/transpilers/python.ts
@@ -231,6 +231,15 @@ function emitStmt(s: Stmt): string {
       return `return ${s.argument ? emitExpr(s.argument) : "None"}`;
     case "ExprStmt":
       return emitExpr(s.expression);
+    // @ts-expect-error -- ForStmt aún no está declarado en el tipo `Stmt`.
+    case "ForStmt": {
+      // TODO: sustituir `any` cuando ForStmt esté tipada en `ast.ts`.
+      const fs = s as any;
+      const it = fs.iterator.name;
+      const expr = emitExpr(fs.expr);
+      const body = emitBlock(fs.body, 2);
+      return `for ${it} in ${expr}:\n${body}`;
+    }
     // TODO: Implementar la transpilación para 'IfStmt'.
     // TODO: Implementar la transpilación para 'MatchStmt' usando 'match/case' de Python.
     default:

--- a/packages/core/tests/python-transpiler.test.ts
+++ b/packages/core/tests/python-transpiler.test.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "vitest";
+import { emitPython } from "../src/transpilers/python.js";
+import type { Program, Identifier, Span, Block } from "../src/ast.js";
+
+const span: Span = { start: { line: 0, column: 0, index: 0 }, end: { line: 0, column: 0, index: 0 } };
+
+function id(name: string): Identifier {
+  return { kind: "Identifier", name, span };
+}
+
+function block(statements: any[]): Block {
+  // TODO: tipar los elementos cuando `ForStmt` esté incluido en el AST.
+  return { kind: "Block", statements, span } as Block;
+}
+
+test("emits for loops", () => {
+  const program: Program = {
+    kind: "Program",
+    items: [
+      {
+        kind: "FuncDecl",
+        name: id("loop"),
+        params: [
+          {
+            kind: "ParamSig",
+            name: id("xs"),
+            type: { kind: "BasicType", name: "Int", span },
+            span,
+          },
+        ],
+        returnType: { kind: "BasicType", name: "Int", span },
+        body: block([
+          {
+            kind: "ForStmt",
+            iterator: id("x"),
+            expr: { kind: "IdentifierExpr", id: id("xs"), span },
+            body: block([]),
+            span,
+          } as any,
+          {
+            kind: "ReturnStmt",
+            argument: { kind: "LiteralExpr", value: { kind: "Number", value: 0, span }, span },
+            span,
+          },
+        ]),
+        span,
+      } as any,
+    ],
+    span,
+  } as any; // TODO: eliminar 'any' cuando el AST soporte ForStmt
+
+  const py = emitPython(program);
+  expect(py).toMatch(/for x in xs:\n\s+pass/);
+});


### PR DESCRIPTION
## Summary
- support `ForStmt` in Python emitter
- cover `emitPython` output with a new unit test

## Testing
- `pnpm -w build`
- `pnpm --filter @il/core test tests/python-transpiler.test.ts`
- `pnpm ilc fmt packages/core/src/transpilers/python.ts` *(fails: Usage: ilc <check|build|test>)*

------
https://chatgpt.com/codex/tasks/task_e_68a711363b548332bf5214a8d8bc9f7d