### PR TITLE
fix: handle refinements and for loop tests

### DIFF
--- a/packages/core/src/lexer.ts
+++ b/packages/core/src/lexer.ts
@@ -27,8 +27,6 @@ export type Token = {
     | "kw_None"
     | "kw_brand"
     | "kw_test"
-    | "kw_for"
-    | "kw_in"
     | "ident"
     | "string"
     | "number"
@@ -92,8 +90,6 @@ const KEYWORDS = new Map<string, Token["type"]>([
   ["None", "kw_None"],
   ["brand", "kw_brand"],
   ["test", "kw_test"],
-  ["for", "kw_for"],
-  ["in", "kw_in"],
 ]);
 
 export function lex(input: string): Token[] {

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -367,8 +367,10 @@ export function parse(input: string): Program {
 
     if (peek("ident") && next().type === "lparen") {
       add(expect("ident").value!);
+      expect("lparen");
       add("(");
       add(JSON.stringify(expect("string").value!));
+      expect("rparen");
       add(")");
     } else {
       const base = expect("ident", "Expected '_' in refinement").value!;
@@ -894,10 +896,7 @@ export function parse(input: string): Program {
   function parseMatchExpr(): MatchExpr {
     const s = spanHere();
     expect("kw_match");
-    const prev = inPattern;
-    inPattern = true;
     const e = parseExpr();
-    inPattern = prev;
     expect("lbrace");
 
     const cases: CaseClause[] = [];

--- a/packages/core/tests/python-transpiler.test.ts
+++ b/packages/core/tests/python-transpiler.test.ts
@@ -1,6 +1,13 @@
 import { test, expect } from "vitest";
 import { emitPython } from "../src/transpilers/python.js";
-import type { Program, Identifier, Span, Block } from "../src/ast.js";
+import type {
+  Program,
+  Identifier,
+  Span,
+  Block,
+  Stmt,
+  Expr,
+} from "../src/ast.js";
 
 const span: Span = { start: { line: 0, column: 0, index: 0 }, end: { line: 0, column: 0, index: 0 } };
 
@@ -8,9 +15,8 @@ function id(name: string): Identifier {
   return { kind: "Identifier", name, span };
 }
 
-function block(statements: any[]): Block {
-  // TODO: tipar los elementos cuando `ForStmt` esté incluido en el AST.
-  return { kind: "Block", statements, span } as Block;
+function block(statements: Stmt[]): Block {
+  return { kind: "Block", statements, span };
 }
 
 test("emits for loops", () => {
@@ -33,21 +39,25 @@ test("emits for loops", () => {
           {
             kind: "ForStmt",
             iterator: id("x"),
-            expr: { kind: "IdentifierExpr", id: id("xs"), span },
+            iterable: { kind: "IdentifierExpr", id: id("xs"), span },
             body: block([]),
             span,
-          } as any,
+          },
           {
             kind: "ReturnStmt",
-            argument: { kind: "LiteralExpr", value: { kind: "Number", value: 0, span }, span },
+            argument: {
+              kind: "LiteralExpr",
+              value: { kind: "Number", value: 0, span },
+              span,
+            },
             span,
           },
         ]),
         span,
-      } as any,
+      },
     ],
     span,
-  } as any; // TODO: eliminar 'any' cuando el AST soporte ForStmt
+  };
 
   const py = emitPython(program);
   expect(py).toMatch(/for x in xs:\n\s+pass/);


### PR DESCRIPTION
## Summary
- remove duplicate `for`/`in` tokens in lexer
- allow `where matches("foo")` refinements and fix `match` scrutinee parsing
- tighten Python transpiler test with typed AST and `iterable`

## Testing
- `pnpm run test:core`
- `pnpm --filter @intentlang/core build`
- `pnpm run intent fmt packages/core/src/lexer.ts packages/core/src/parser.ts packages/core/tests/python-transpiler.test.ts` *(fails: Cannot find module '/workspace/IntentLang/packages/cli/dist/index.js')*
- `pnpm test` *(fails: Cannot find module '/workspace/IntentLang/packages/cli/dist/index.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a6ff0c606883329c8db9fcb2b90694