### PR TITLE
chore: add npmrc for workspace peers

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Automatically install peer dependencies and relax strictness for the pnpm workspace
+auto-install-peers=true
+strict-peer-dependencies=false


### PR DESCRIPTION
## Summary
- add `.npmrc` to auto-install peer dependencies and relax strict peer dependency enforcement in the pnpm workspace

## Testing
- `pnpm -r build`
- `pnpm -w typecheck`
- `pnpm test` *(fails: tests/ilc-check.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a6f2fe78833281b7a936015a7ec1