### PR TITLE
feat(core): add const declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@
 * **core:** align transpilers and simplify AST handling ([6674bca](https://github.com/alessbarb/IntentLang/commit/6674bca6a4594f1e3e51c4b6471e36386102ecd4))
 
 ## [Unreleased]
+### Features
+
+- **core:** support immutable `const` declarations.
+
+### Bug Fixes
+
+- **core:** emit mutable declarations for `let` in TypeScript transpiler.
 
 ### Docs
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ func add(a: Int, b: Int): Int
   ensures _ >= a && _ >= b
 { return a + b; }
 
-test add_works { let r = random.int(); }
+test add_works { const r = random.int(); }
 ```
 
 ### For loops

--- a/docs/grammar/EBNF.md
+++ b/docs/grammar/EBNF.md
@@ -115,7 +115,7 @@ ContractBlock   = [ "requires" , Expr ] , [ "ensures" , Expr ] ;
 Block           = "{" , ws , { Stmt } , "}" ;
 Stmt            = LetStmt | ReturnStmt | IfStmt | MatchStmt | ForStmt | ExprStmt ;
 
-LetStmt         = "let" , ident , "=" , Expr , [";"] ;
+LetStmt         = ("let" | "const") , ident , "=" , Expr , [";"] ;
 ReturnStmt      = "return" , [ Expr ] , [";"] ;
 IfStmt          = "if" , Expr , Block , [ "else" , Block ] ;
 MatchStmt       = MatchExpr , [";"] ;

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -44,7 +44,7 @@ effect createUser(input: CreateUserInput): ResultUser uses http, clock
   ensures _.id != ""
 { }
 
-test create_user { let now = clock.now(); }
+test create_user { const now = clock.now(); }
 ```
 
 ## Validate the file

--- a/docs/guide/tests.md
+++ b/docs/guide/tests.md
@@ -13,9 +13,9 @@ func add(a: Int, b: Int): Int
 effect rollDie(): Int uses random { }
 
 test deterministic {
-  let sum = add(2, 3);
-  let r1 = rollDie();
-  let r2 = rollDie();
+  const sum = add(2, 3);
+  const r1 = rollDie();
+  const r2 = rollDie();
   // assertions will come in future versions
 }
 ```

--- a/packages/core/src/ast.ts
+++ b/packages/core/src/ast.ts
@@ -180,6 +180,10 @@ export type LetStmt = {
   kind: "LetStmt";
   id: Identifier;
   init: Expr;
+  /**
+   * Whether this binding is mutable (`let`) or immutable (`const`).
+   */
+  mutable: boolean;
   span: Span;
 };
 export type ReturnStmt = { kind: "ReturnStmt"; argument?: Expr; span: Span };

--- a/packages/core/src/lexer.ts
+++ b/packages/core/src/lexer.ts
@@ -14,6 +14,7 @@ export type Token = {
     | "kw_ensures"
     | "kw_return"
     | "kw_let"
+    | "kw_const"
     | "kw_if"
     | "kw_else"
     | "kw_match"
@@ -90,6 +91,7 @@ const KEYWORDS = new Map<string, Token["type"]>([
   ["ensures", "kw_ensures"],
   ["return", "kw_return"],
   ["let", "kw_let"],
+  ["const", "kw_const"],
   ["if", "kw_if"],
   ["else", "kw_else"],
   ["match", "kw_match"],

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -511,7 +511,7 @@ export function parse(input: string): Program {
   }
 
   function parseStmt(): Stmt {
-    if (peek("kw_let")) return parseLetStmt();
+    if (peek("kw_let") || peek("kw_const")) return parseLetStmt();
     if (peek("kw_return")) return parseReturnStmt();
     if (peek("kw_if")) return parseIfStmt();
     if (peek("kw_match")) return parseMatchStmt();
@@ -523,12 +523,13 @@ export function parse(input: string): Program {
 
   function parseLetStmt(): LetStmt {
     const s = spanHere();
-    expect("kw_let");
+    const mutable = peek("kw_let");
+    expect(mutable ? "kw_let" : "kw_const");
     const id = parseIdent();
     expect("eq");
     const init = parseExpr();
     eat("semi");
-    return { kind: "LetStmt", id, init, span: s };
+    return { kind: "LetStmt", id, init, mutable, span: s };
   }
 
   function parseReturnStmt(): ReturnStmt {

--- a/packages/core/src/transpilers/typescript.ts
+++ b/packages/core/src/transpilers/typescript.ts
@@ -224,7 +224,8 @@ function emitStmt(s: Stmt, isEffect: boolean, ensures?: Expr): string {
   switch (s.kind) {
     case "LetStmt": {
       const init = emitExpr(s.init, isEffect);
-      return `const ${s.id.name} = ${init};`;
+      const kw = s.mutable ? "let" : "const";
+      return `${kw} ${s.id.name} = ${init};`;
     }
     case "ReturnStmt": {
       if (!s.argument) {

--- a/packages/core/tests/operators.test.ts
+++ b/packages/core/tests/operators.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "vitest";
 import { lex } from "../src/lexer.js";
 import { parse } from "../src/parser.js";
+import { emitTypeScript } from "../src/transpilers/typescript.js";
 
 test("lexes extended operators", () => {
   const tokens = lex("a+=1; b--; c&d | e ^ ~f << 1 >> 2 ? g : h");
@@ -27,4 +28,16 @@ test("parses compound, update and ternary", () => {
   const ret = body[3];
   expect(ret.kind).toBe("ReturnStmt");
   expect((ret as any).argument.kind).toBe("ConditionalExpr");
+});
+
+test("transpiles let as mutable in TypeScript", () => {
+  const program = parse("test t { let n = 0; n += 1; }");
+  const ts = emitTypeScript(program);
+  expect(ts).toContain("let n = 0;");
+});
+
+test("transpiles const as immutable in TypeScript", () => {
+  const program = parse("test t { const n = 0; }");
+  const ts = emitTypeScript(program);
+  expect(ts).toContain("const n = 0;");
 });

--- a/packages/examples/goldens/operators.ts
+++ b/packages/examples/goldens/operators.ts
@@ -34,7 +34,7 @@ export type Option<T> = { kind: "some"; value: T } | { kind: "none" };
 export type Capabilities = {};
 
 export async function test_operators(): Promise<void> {
-  const n = 5;
+  let n = 5;
   n += 3;
   n -= 1;
   n *= 2;


### PR DESCRIPTION
## Summary
- add `const` keyword for immutable bindings
- emit `const` in TypeScript transpiler and update docs, tests, and goldens

## Testing
- `pnpm -w build`
- `pnpm -w test` *(fails: expected 'Error: No input files found matching …' to match /Usage: intent/)*
- `pnpm --filter @intentlang/core test`
- `pnpm --filter @intentlang/examples test:goldens` *(fails: Cannot find package '@il/core')*
- `pnpm -w typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a7ab98d5a483328b4d65d2dc84ab75