### PR TITLE
feat(core): make intent tags optional

### DIFF
--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -149,7 +149,9 @@ export function parse(input: string): Program {
     const s = spanHere();
     expect("kw_intent");
     const description = expect("string").value!;
-    expect("kw_tags");
+    if (!eat("kw_tags")) {
+      return { kind: "IntentSection", description, span: s };
+    }
     expect("lbrack");
     const tags: string[] = [];
     if (!peek("rbrack")) {

--- a/packages/core/tests/intent-tags.test.ts
+++ b/packages/core/tests/intent-tags.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "vitest";
+import { parse } from "../src/parser.js";
+
+// Ensure intent section accepts optional tags
+
+test("parses intent without tags", () => {
+  const program = parse('intent "Svc"');
+  expect(program.intent?.description).toBe("Svc");
+  expect(program.intent?.tags).toBeUndefined();
+});
+
+test("parses intent with tags", () => {
+  const program = parse('intent "Svc" tags ["a", "b"]');
+  expect(program.intent?.tags).toEqual(["a", "b"]);
+});


### PR DESCRIPTION
## Summary
- allow `intent` sections without `tags`
- add parser test covering optional tags

## Testing
- `pnpm -w build`
- `pnpm --filter @intentlang/core test` *(fails: Expected union constructor after '|')*


------
https://chatgpt.com/codex/tasks/task_e_68a879ea4bb0833295233557442b6d5b