### PR TITLE
docs: clarify optional intent tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Docs
+
+- document optional `intent` tags in grammar and guides.
+
 ## [1.13.2](https://github.com/alessbarb/IntentLang/compare/v1.13.1...v1.13.2) (2025-08-22)
 
 ### Bug Fixes

--- a/docs/grammar/EBNF.md
+++ b/docs/grammar/EBNF.md
@@ -44,7 +44,7 @@ File            = ws ,
 ## Sections
 
 ```ebnf
-IntentSection   = "intent" , string , "tags" , "[" , [ string , { "," , string } ] , "]" ;
+IntentSection   = "intent" , string , [ "tags" , "[" , string , { "," , string } , "]" ] ;
 
 UsesSection     = "uses" , "{" , ws , { UseDecl } , "}" ;
 UseDecl         = ident , ":" , ident , [ RecordExpr ] , [","] ;

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -13,10 +13,10 @@ pnpm install
 
 ## Create a simple service
 
-Create `user_service.il` with the following content:
+Create `user_service.il` with the following content. The `tags` clause is optional and omitted here.
 
 ```intentlang
-intent "User service" tags ["api", "users"]
+intent "User service"
 
 uses {
   http: Http { baseUrl: "https://api.example.com", timeoutMs: 2500 },
@@ -46,6 +46,8 @@ effect createUser(input: CreateUserInput): ResultUser uses http, clock
 
 test create_user { let now = clock.now(); }
 ```
+
+If needed, add tags after the service name, e.g. `intent "User service" tags ["api", "users"]`.
 
 ## Validate the file
 

--- a/docs/reference/syntax.md
+++ b/docs/reference/syntax.md
@@ -2,16 +2,16 @@
 
 An `.il` file must follow this order of sections:
 
-1. `intent` – describes the service and its tags.
+1. `intent` – describes the service and optionally its tags.
 2. `uses` – declares external capabilities.
 3. `types` – defines domain types.
 4. `func` – pure functions.
 5. `effect` – functions with effects.
 
-Minimal example:
+Tags are optional; the example below omits the `tags` clause. Add them with `tags ["demo"]` when needed.
 
 ```intentlang
-intent "Ping" tags ["demo"]
+intent "Ping"
 
 uses {
   clock: Clock {}

--- a/packages/core/grammar/intentlang.ebnf
+++ b/packages/core/grammar/intentlang.ebnf
@@ -27,7 +27,7 @@ File            = ws ,
 
 
 (* ---------- Sections ---------- *)
-IntentSection   = "intent" , string , "tags" , "[" , [ string , { "," , string } ] , "]" ;
+IntentSection   = "intent" , string , [ "tags" , "[" , string , { "," , string } , "]" ] ;
 
 UsesSection     = "uses" , "{" , ws , { UseDecl } , "}" ;
 UseDecl         = ident , ":" , ident , [ RecordExpr ] , [","] ;


### PR DESCRIPTION
## Summary
- allow omitting `tags` in `intent` section EBNF
- document optional `intent` tags and provide tagless examples
- note optional tags in quickstart and syntax guides

## Testing
- `pnpm -w build` *(fails: No input files specified and no 'include' pattern found in ilconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a70f16588332847b92fb07a0d6f0