### PR TITLE
docs: clarify optional tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Please follow these rules when writing `.il` files:
 
 ### File order
 
-1. `intent` — purpose + tags
+1. `intent` — purpose, optional tags
 2. `uses` — declared external capabilities (http, clock, random, …)
 3. `types` — brands → records → unions
 4. `func` — pure helpers (no I/O)

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -9,7 +9,7 @@ It is aimed at **developers and AIs generating IL code**.
 
 A `.il` file must follow this order:
 
-1. `intent` — short description + tags
+1. `intent` — short description, optional tags
 2. `uses` — declared external capabilities (http, clock, random, …)
 3. `types` — brand types → record types → union types
 4. `func` — pure helper functions (no I/O)
@@ -127,7 +127,8 @@ Examples of common errors:
 ### File skeleton
 
 ```intentlang
-intent "Service name" tags ["tag1","tag2"]
+intent "Service name"
+// or: intent "Service name" tags ["tag1","tag2"]
 
 uses {
   http: Http { baseUrl: "https://api.example.com", timeoutMs: 2000 },


### PR DESCRIPTION
## Summary
- clarify that `intent` statements include optional tags
- update style guide template to show intent with and without tags
- note optional tags in contributing guide

## Testing
- `pnpm run fmt` *(fails: Missing script fmt)*
- `pnpm -w lint`
- `pnpm -w build` *(fails: No input files specified in examples)*
- `pnpm -w typecheck`
- `pnpm test` *(fails: parser errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a858906883328b0c6dcfad231b6f