### PR TITLE
feat(core): make intent tags optional

### DIFF
--- a/docs/grammar/EBNF.md
+++ b/docs/grammar/EBNF.md
@@ -44,7 +44,8 @@ File            = ws ,
 ## Sections
 
 ```ebnf
-IntentSection   = "intent" , string , [ "tags" , "[" , string , { "," , string } , "]" ] ;
+IntentSection   = "intent" , string , [ TagList ] ;
+TagList         = "tags" , "[" , string , { "," , string } , "]" ;
 
 UsesSection     = "uses" , "{" , ws , { UseDecl } , "}" ;
 UseDecl         = ident , ":" , ident , [ RecordExpr ] , [","] ;

--- a/packages/core/grammar/intentlang.ebnf
+++ b/packages/core/grammar/intentlang.ebnf
@@ -27,7 +27,8 @@ File            = ws ,
 
 
 (* ---------- Sections ---------- *)
-IntentSection   = "intent" , string , [ "tags" , "[" , string , { "," , string } , "]" ] ;
+IntentSection   = "intent" , string , [ TagList ] ;
+TagList         = "tags" , "[" , string , { "," , string } , "]" ;
 
 UsesSection     = "uses" , "{" , ws , { UseDecl } , "}" ;
 UseDecl         = ident , ":" , ident , [ RecordExpr ] , [","] ;

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -149,16 +149,16 @@ export function parse(input: string): Program {
     const s = spanHere();
     expect("kw_intent");
     const description = expect("string").value!;
-    if (!eat("kw_tags")) {
-      return { kind: "IntentSection", description, span: s };
+    let tags: string[] | undefined;
+    if (eat("kw_tags")) {
+      expect("lbrack");
+      tags = [];
+      if (!peek("rbrack")) {
+        tags.push(expect("string").value!);
+        while (eat("comma")) tags.push(expect("string").value!);
+      }
+      expect("rbrack");
     }
-    expect("lbrack");
-    const tags: string[] = [];
-    if (!peek("rbrack")) {
-      tags.push(expect("string").value!);
-      while (eat("comma")) tags.push(expect("string").value!);
-    }
-    expect("rbrack");
     return { kind: "IntentSection", description, tags, span: s };
   }
 


### PR DESCRIPTION
## Summary
- allow intent sections to omit tags
- parseIntent now returns `tags` only when provided
- document optional tag list in EBNF

## Testing
- `pnpm -w build` *(fails: Error: No input files specified and no 'include' pattern found in ilconfig.json.)*
- `pnpm -w test` *(fails: Expected union constructor after '|' at 3:30)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ad09610c8332bc16c65e8768d659