### PR TITLE
docs(core): document generation workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:core": "pnpm --filter @intentlang/core test",
     "test:cli": "pnpm --filter @intentlang/cli test",
     "typecheck": "pnpm -r run typecheck",
-    "intent": "node packages/cli/dist/index.js"
+    "intent": "node packages/cli/dist/index.js",
+    "generate": "pnpm --filter @intentlang/core run generate:all"
   },
   "bin": {
     "intent": "packages/cli/dist/index.js"

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -31,6 +31,7 @@ Refer first to the [repository-wide guide](../../AGENTS.md). This file adds rule
 
 ## PR checklist (Core)
 
+- [ ] `pnpm run generate` executed.
 - [ ] `pnpm -w build` passes.
 - [ ] `intent check` on examples (if touched) passes.
 - [ ] Tests for lexer/parser/checker/transpiler added.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,6 +3,19 @@
 Core libraries for **IntentLang**: parser, AST, type checker, transpiler, and
 runtime helpers used by the CLI.
 
+## Generación automática
+
+Ejecuta `pnpm run generate` para regenerar los artefactos derivados. Este
+comando actualiza:
+
+- `grammar/IntentLang.g4`
+- Archivos de gramática en `src/generated/grammar/` como
+  `IntentLangParser.ts`, `IntentLangLexer.ts` y `IntentLangVisitor.ts`
+- Los archivos `src/nodes.gen.ts` y `src/visitor.gen.ts`
+
+Incluye estos archivos generados en los commits para mantener el repositorio
+consistente.
+
 ## Usage
 
 ```ts

--- a/packages/core/tests/generation.test.ts
+++ b/packages/core/tests/generation.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { test, expect } from "vitest";
+
+const root = resolve(__dirname, "../src/generated/grammar");
+
+test("visitor.gen.ts expone visitProgram", () => {
+  const file = resolve(root, "IntentLangVisitor.ts");
+  const content = readFileSync(file, "utf8");
+  expect(content).toContain("visitProgram?:");
+});
+
+test("nodes.gen.ts incluye ProgramContext", () => {
+  const file = resolve(root, "IntentLangParser.ts");
+  const content = readFileSync(file, "utf8");
+  expect(content).toMatch(/class\s+ProgramContext/);
+});


### PR DESCRIPTION
## Summary
- document automatic code generation in core README
- require running `pnpm run generate` in core AGENTS guide
- add basic tests ensuring generated visitor and parser nodes exist
- expose workspace `pnpm run generate` script

## Testing
- `pnpm run generate`
- `pnpm -w build`
- `pnpm -w typecheck`
- `pnpm --filter @intentlang/core test tests/generation.test.ts`
- `pnpm run intent test` *(fails: Command failed with exit code 2)*
- `pnpm run intent check` *(fails: No input files specified)*
- `pnpm run intent fmt` *(fails: No files matched)*

------
https://chatgpt.com/codex/tasks/task_e_68aa404bb6c48332b76c8874b857e40e