### PR TITLE
Add generation safeguards and grammar coverage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,19 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Generate
+        run: pnpm run generate
+      - name: Typecheck
+        run: pnpm -w typecheck
       - name: Lint
         run: pnpm lint
-      - name: Test
-        run: pnpm test
       - name: Build
         run: pnpm build
+      - name: intent check
+        run: pnpm intent check
+      - name: intent test
+        run: pnpm intent test
+      - name: Unit tests
+        run: pnpm test
+      - name: Ensure generated artifacts committed
+        run: git diff --exit-code

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:core": "pnpm --filter @intentlang/core test",
     "test:cli": "pnpm --filter @intentlang/cli test",
     "typecheck": "pnpm -r run typecheck",
+    "generate": "pnpm --filter @intentlang/core run generate",
     "intent": "node packages/cli/dist/index.js"
   },
   "bin": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -30,6 +30,20 @@ pnpm --filter @intentlang/core build    # compile TypeScript
 pnpm --filter @intentlang/core test     # run unit tests
 ```
 
+### When to run `pnpm run generate`
+
+Run `pnpm run generate` after modifying the grammar or generation scripts. It
+regenerates ANTLR artifacts and verifies that any `*.manual.ts` files remain
+unchanged, aborting if they differ.
+
+Once generation completes, run the test suite. `generation.spec.ts` checks that
+every grammar rule has a corresponding `visitX` method and context node in the
+generated sources. Failing tests indicate the grammar and generated files are
+out of sync.
+
+Skipping this step risks committing stale parser code or overwriting manual
+patches, leading to confusing build or runtime errors.
+
 ### Grammar Workflow (EBNF → ANTLR → TS)
 
 The grammar is maintained in **EBNF** (`grammar/intentlang.ebnf`) as the single

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
   ],
   "sideEffects": false,
   "scripts": {
+    "generate": "node ./scripts/generate.mjs",
     "generate:g4": "node ./scripts/ebnf2g4.mjs -i ./grammar/IntentLang.ebnf -o ./grammar/IntentLang.g4 --grammar IntentLang",
     "generate:antlr": "npx antlr4ts-cli -visitor -o ./src/generated ./grammar/IntentLang.g4 && node ./scripts/patch-antlr-esm.mjs ./src/generated/",
     "generate:all": "pnpm run generate:g4 && pnpm run generate:antlr",

--- a/packages/core/scripts/generate.mjs
+++ b/packages/core/scripts/generate.mjs
@@ -1,0 +1,47 @@
+import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, out);
+    } else if (entry.isFile() && entry.name.endsWith('.manual.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function hash(file) {
+  return createHash('sha256').update(readFileSync(file)).digest('hex');
+}
+
+const manualFiles = walk(root);
+const before = new Map(manualFiles.map(f => [f, hash(f)]));
+
+function run(cmd) {
+  execSync(cmd, { cwd: root, stdio: 'inherit', env: { ...process.env, npm_config_yes: 'true' } });
+}
+
+run('node ./scripts/ebnf2g4.mjs -i ./grammar/IntentLang.ebnf -o ./grammar/IntentLang.g4 --grammar IntentLang');
+run('npx -y antlr4ts-cli -visitor -o ./src/generated ./grammar/IntentLang.g4');
+run('node ./scripts/patch-antlr-esm.mjs ./src/generated/');
+
+let changed = false;
+for (const file of manualFiles) {
+  if (before.get(file) !== hash(file)) {
+    console.error(`Manual file modified by generation: ${file}`);
+    changed = true;
+  }
+}
+
+if (changed) {
+  process.exit(1);
+}

--- a/packages/core/tests/generation.spec.ts
+++ b/packages/core/tests/generation.spec.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, test, expect } from 'vitest';
+
+const pkgRoot = join(__dirname, '..');
+const grammarPath = join(pkgRoot, 'grammar/IntentLang.g4');
+const visitorPath = join(pkgRoot, 'src/generated/grammar/IntentLangVisitor.ts');
+const nodesPath = join(pkgRoot, 'src/generated/grammar/IntentLangParser.ts');
+
+const grammar = readFileSync(grammarPath, 'utf8');
+const ruleNames = grammar
+  .split('\n')
+  .map((l) => l.trim())
+  .filter((l) => /^[a-z][A-Za-z0-9_]*\s*:/.test(l))
+  .map((l) => l.split(/\s*:/)[0]);
+
+const cap = (s: string): string => s[0].toUpperCase() + s.slice(1);
+const visitorGen = readFileSync(visitorPath, 'utf8');
+const nodesGen = readFileSync(nodesPath, 'utf8');
+
+describe('generated artifacts match grammar', () => {
+  test('visitor has visit methods for every rule', () => {
+    for (const r of ruleNames) {
+      expect(visitorGen).toContain(`visit${cap(r)}`);
+    }
+  });
+
+  test('parser exposes context for every rule', () => {
+    for (const r of ruleNames) {
+      expect(nodesGen).toMatch(new RegExp(`class\\s+${cap(r)}Context`));
+    }
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.{test,spec}.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- ensure manual `*.manual.ts` files remain unchanged during generation
- verify generated visitor and parser nodes cover grammar rules
- wire generate/typecheck/intent checks into CI and document generation workflow

## Testing
- `pnpm run generate`
- `pnpm -w typecheck` *(fails: Cannot find module '@intentlang/core')*
- `pnpm intent check` *(fails: Cannot find module '/workspace/IntentLang/packages/cli/dist/index.js')*
- `pnpm intent test` *(fails: Cannot find module '/workspace/IntentLang/packages/cli/dist/index.js')*
- `pnpm test` *(fails: Cannot find module '../src/parser.js')*


------
https://chatgpt.com/codex/tasks/task_e_68aa40c798ec83329d43297a30b0295a